### PR TITLE
Apply cargo fmt formatting cleanup

### DIFF
--- a/src/clients.rs
+++ b/src/clients.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
+use aes::cipher::{generic_array::GenericArray, BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
 use async_shutdown::TriggerShutdownToken;
 use ring::{
@@ -507,12 +507,14 @@ impl ClientManagerInner {
 
 		// Generate a random server secret.
 		let mut server_secret = [0u8; 16];
-		SystemRandom::new().fill(&mut server_secret).map_err(|_| "Failed to generate random".to_string())?;
+		SystemRandom::new()
+			.fill(&mut server_secret)
+			.map_err(|_| "Failed to generate random".to_string())?;
 
 		client.server_secret = Some(server_secret);
 
-		let mut decrypted = aes_decrypt_ecb(&challenge, key)
-			.map_err(|e| format!("Failed to decrypt client challenge: {e}"))?;
+		let mut decrypted =
+			aes_decrypt_ecb(&challenge, key).map_err(|e| format!("Failed to decrypt client challenge: {e}"))?;
 
 		// Parse server cert to get signature
 		let signature_bytes = extract_certificate_signature(&self.server_certs)
@@ -522,7 +524,9 @@ impl ClientManagerInner {
 		decrypted.extend_from_slice(&server_secret);
 
 		let mut server_challenge = [0u8; 16];
-		SystemRandom::new().fill(&mut server_challenge).map_err(|_| "Failed to generate random".to_string())?;
+		SystemRandom::new()
+			.fill(&mut server_challenge)
+			.map_err(|_| "Failed to generate random".to_string())?;
 
 		client.server_challenge = Some(server_challenge);
 
@@ -595,20 +599,22 @@ fn sign(data: &[u8], key_pem: &str) -> Result<Vec<u8>, String> {
 	};
 
 	// We strictly use RSA for Moonshine hosting
-	let key_pair = RsaKeyPair::from_pkcs8(
-		&key_bytes,
-	).map_err(|e| format!("Failed to load RSA key pair: {}", e))?;
+	let key_pair = RsaKeyPair::from_pkcs8(&key_bytes).map_err(|e| format!("Failed to load RSA key pair: {}", e))?;
 
 	let rng = SystemRandom::new();
 	let mut signature = vec![0; key_pair.public().modulus_len()];
 
-	key_pair.sign(&RSA_PKCS1_SHA256, &rng, data, &mut signature).map_err(|e| format!("Failed to sign data: {}", e))?;
+	key_pair
+		.sign(&RSA_PKCS1_SHA256, &rng, data, &mut signature)
+		.map_err(|e| format!("Failed to sign data: {}", e))?;
 	Ok(signature)
 }
 
 fn extract_certificate_signature(pem: &str) -> Result<Vec<u8>, String> {
 	let (_, pem_obj) = parse_x509_pem(pem.as_bytes()).map_err(|e| format!("Failed to parse PEM: {}", e))?;
-	let cert = pem_obj.parse_x509().map_err(|e| format!("Failed to parse X509: {}", e))?;
+	let cert = pem_obj
+		.parse_x509()
+		.map_err(|e| format!("Failed to parse X509: {}", e))?;
 	Ok(cert.signature_value.data.to_vec())
 }
 
@@ -629,7 +635,10 @@ async fn check_client_pairing_secret(client: &mut PendingClient, client_secret: 
 
 	// We expect at least 16 bytes.
 	if client_secret.len() < 16 {
-		return Err(format!("Expected client pairing secret to be at least 16 bytes, but got {}", client_secret.len()));
+		return Err(format!(
+			"Expected client pairing secret to be at least 16 bytes, but got {}",
+			client_secret.len()
+		));
 	}
 
 	let client_secret_payload = &client_secret[..16];

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -4,18 +4,20 @@ use aes_gcm::{
 	Aes128Gcm, Key, Nonce,
 };
 use rand::RngCore;
-use rcgen::{BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose, SerialNumber};
+use rcgen::{
+	BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose, SerialNumber,
+};
 use rsa::{
-    pkcs8::{EncodePrivateKey, LineEnding},
-    RsaPrivateKey,
+	pkcs8::{EncodePrivateKey, LineEnding},
+	RsaPrivateKey,
 };
 use std::time::{Duration, SystemTime};
 
 pub fn create_certificate() -> Result<(String, String), Box<dyn std::error::Error>> {
-    // Generate RSA key (2048 bits)
-    let mut rng = rand::rngs::OsRng;
-    let private_key = RsaPrivateKey::new(&mut rng, 2048)?;
-    let key_pem = private_key.to_pkcs8_pem(LineEnding::LF)?.to_string();
+	// Generate RSA key (2048 bits)
+	let mut rng = rand::rngs::OsRng;
+	let private_key = RsaPrivateKey::new(&mut rng, 2048)?;
+	let key_pem = private_key.to_pkcs8_pem(LineEnding::LF)?.to_string();
 
 	let mut params = CertificateParams::default();
 	params.not_before = SystemTime::now().into();
@@ -39,12 +41,7 @@ pub fn create_certificate() -> Result<(String, String), Box<dyn std::error::Erro
 	Ok((cert.pem(), key_pem))
 }
 
-pub fn encrypt(
-	plaintext: &[u8],
-	key: &[u8],
-	iv: &[u8],
-	tag: &mut [u8],
-) -> Result<Vec<u8>, aes_gcm::Error> {
+pub fn encrypt(plaintext: &[u8], key: &[u8], iv: &[u8], tag: &mut [u8]) -> Result<Vec<u8>, aes_gcm::Error> {
 	let key = Key::<Aes128Gcm>::from_slice(key);
 	let nonce = Nonce::from_slice(iv);
 	let cipher = Aes128Gcm::new(key);
@@ -90,7 +87,8 @@ pub fn encrypt_cbc(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>, String
 	let pos = data.len();
 	buffer[..pos].copy_from_slice(data);
 
-	let ct_len = cipher.encrypt_padded_mut::<block_padding::Pkcs7>(&mut buffer, pos)
+	let ct_len = cipher
+		.encrypt_padded_mut::<block_padding::Pkcs7>(&mut buffer, pos)
 		.map_err(|e| format!("Padding error: {:?}", e))?
 		.len();
 

--- a/src/session/stream/audio/encoder.rs
+++ b/src/session/stream/audio/encoder.rs
@@ -182,11 +182,7 @@ impl AudioEncoderInner {
 			let iv = keys.remote_input_key_id as u32 + sequence_number as u32;
 			let mut iv = iv.to_be_bytes().to_vec();
 			iv.extend([0u8; 12]);
-			let payload = match encrypt_cbc(
-				&encoded_audio[..encoded_size],
-				&keys.remote_input_key,
-				&iv,
-			) {
+			let payload = match encrypt_cbc(&encoded_audio[..encoded_size], &keys.remote_input_key, &iv) {
 				Ok(payload) => payload,
 				Err(e) => {
 					tracing::error!("Failed to encrypt audio: {e}");

--- a/src/session/stream/control/mod.rs
+++ b/src/session/stream/control/mod.rs
@@ -181,22 +181,13 @@ fn encode_control(key: &[u8], sequence_number: u32, payload: &[u8]) -> Result<Ve
 	initialization_vector[11] = b'C';
 
 	if key.len() != 16 {
-		tracing::warn!(
-			"Key length has {} bytes, but expected {} bytes.",
-			key.len(),
-			16
-		);
+		tracing::warn!("Key length has {} bytes, but expected {} bytes.", key.len(), 16);
 		return Err(());
 	}
 
 	let mut tag = [0u8; 16];
-	let payload = encrypt(
-		payload,
-		key,
-		&initialization_vector,
-		&mut tag,
-	)
-	.map_err(|e| tracing::warn!("Failed to encrypt control data: {e}"))?;
+	let payload = encrypt(payload, key, &initialization_vector, &mut tag)
+		.map_err(|e| tracing::warn!("Failed to encrypt control data: {e}"))?;
 
 	if payload.is_empty() {
 		tracing::warn!("Failed to encrypt control data.");

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -280,150 +280,150 @@ impl VideoPipelineInner {
 
 				// Zero-copy DMA-BUF path - import directly to Vulkan image.
 				let dmabuf_info = &frame.dmabuf;
-					tracing::debug!(
-						"Received frame: format={:?}, {}x{}, fd={}, offset={}, stride={}",
-						frame.format,
-						dmabuf_info.width,
-						dmabuf_info.height,
-						dmabuf_info.fd,
-						dmabuf_info.offset,
-						dmabuf_info.stride
-					);
-					let importer = match &mut dmabuf_importer {
-						Some(imp) => imp,
-						None => match DmaBufImporter::new(context.clone()) {
-							Ok(imp) => {
-								dmabuf_importer = Some(imp);
-								dmabuf_importer.as_mut().unwrap()
-							},
-							Err(e) => {
-								tracing::error!("Failed to create DMA-BUF importer: {e}");
-								continue;
-							},
+				tracing::debug!(
+					"Received frame: format={:?}, {}x{}, fd={}, offset={}, stride={}",
+					frame.format,
+					dmabuf_info.width,
+					dmabuf_info.height,
+					dmabuf_info.fd,
+					dmabuf_info.offset,
+					dmabuf_info.stride
+				);
+				let importer = match &mut dmabuf_importer {
+					Some(imp) => imp,
+					None => match DmaBufImporter::new(context.clone()) {
+						Ok(imp) => {
+							dmabuf_importer = Some(imp);
+							dmabuf_importer.as_mut().unwrap()
 						},
-					};
-
-					// Create DmaBufPlane from the info.
-					let plane = DmaBufPlane {
-						fd: dmabuf_info.fd,
-						offset: dmabuf_info.offset,
-						stride: dmabuf_info.stride,
-						modifier: dmabuf_info.modifier,
-					};
-					let planes = [plane];
-
-					// Handle based on format.
-					let encode_result = match frame.format {
-						CapturePixelFormat::NV12 => {
-							// NV12 DMA-BUF can be passed directly to encoder (zero-copy)
-							let dmabuf_image =
-								match importer.import_nv12(dmabuf_info.width, dmabuf_info.height, &planes) {
-									Ok(img) => img,
-									Err(e) => {
-										tracing::error!("Failed to import NV12 DMA-BUF: {e}");
-										continue;
-									},
-								};
-							encoder.encode(dmabuf_image.image())
+						Err(e) => {
+							tracing::error!("Failed to create DMA-BUF importer: {e}");
+							continue;
 						},
-						CapturePixelFormat::BGRx
-						| CapturePixelFormat::BGRA
-						| CapturePixelFormat::RGBx
-						| CapturePixelFormat::RGBA => {
-							// RGB DMA-BUF needs conversion to YUV.
-							let input_format = match frame.format {
-								CapturePixelFormat::BGRx => InputFormat::BGRx,
-								CapturePixelFormat::RGBx => InputFormat::RGBx,
-								CapturePixelFormat::BGRA => InputFormat::BGRA,
-								CapturePixelFormat::RGBA => InputFormat::RGBA,
-								_ => unreachable!(),
-							};
+					},
+				};
 
-							// Import the DMA-BUF as a Vulkan image.
-							let dmabuf_image = match frame.format {
-								CapturePixelFormat::BGRx | CapturePixelFormat::BGRA => {
-									importer.import_bgra(dmabuf_info.width, dmabuf_info.height, &planes)
-								},
-								CapturePixelFormat::RGBx | CapturePixelFormat::RGBA => {
-									importer.import_rgba(dmabuf_info.width, dmabuf_info.height, &planes)
-								},
-								_ => unreachable!(),
-							};
+				// Create DmaBufPlane from the info.
+				let plane = DmaBufPlane {
+					fd: dmabuf_info.fd,
+					offset: dmabuf_info.offset,
+					stride: dmabuf_info.stride,
+					modifier: dmabuf_info.modifier,
+				};
+				let planes = [plane];
 
-							let dmabuf_image = match dmabuf_image {
+				// Handle based on format.
+				let encode_result = match frame.format {
+					CapturePixelFormat::NV12 => {
+						// NV12 DMA-BUF can be passed directly to encoder (zero-copy)
+						let dmabuf_image =
+							match importer.import_nv12(dmabuf_info.width, dmabuf_info.height, &planes) {
 								Ok(img) => img,
 								Err(e) => {
-									tracing::error!("Failed to import RGB DMA-BUF: {e}");
+									tracing::error!("Failed to import NV12 DMA-BUF: {e}");
 									continue;
 								},
 							};
+						encoder.encode(dmabuf_image.image())
+					},
+					CapturePixelFormat::BGRx
+					| CapturePixelFormat::BGRA
+					| CapturePixelFormat::RGBx
+					| CapturePixelFormat::RGBA => {
+						// RGB DMA-BUF needs conversion to YUV.
+						let input_format = match frame.format {
+							CapturePixelFormat::BGRx => InputFormat::BGRx,
+							CapturePixelFormat::RGBx => InputFormat::RGBx,
+							CapturePixelFormat::BGRA => InputFormat::BGRA,
+							CapturePixelFormat::RGBA => InputFormat::RGBA,
+							_ => unreachable!(),
+						};
 
-							// Initialize converter if needed.
-							let converter = match &mut color_converter {
-								Some(conv) => conv,
-								None => {
-									let config = ColorConverterConfig {
-										width: self.width,
-										height: self.height,
-										input_format,
-										output_format,
-									};
-									match ColorConverter::new(context.clone(), config) {
-										Ok(conv) => {
-											color_converter = Some(conv);
-											color_converter.as_mut().unwrap()
-										},
-										Err(e) => {
-											tracing::error!("Failed to create color converter: {e}");
-											continue;
-										},
-									}
-								},
-							};
+						// Import the DMA-BUF as a Vulkan image.
+						let dmabuf_image = match frame.format {
+							CapturePixelFormat::BGRx | CapturePixelFormat::BGRA => {
+								importer.import_bgra(dmabuf_info.width, dmabuf_info.height, &planes)
+							},
+							CapturePixelFormat::RGBx | CapturePixelFormat::RGBA => {
+								importer.import_rgba(dmabuf_info.width, dmabuf_info.height, &planes)
+							},
+							_ => unreachable!(),
+						};
 
-							// Convert RGB to YUV directly into the encoder's input image.
-							if let Err(e) = converter.convert(dmabuf_image.image(), encoder.input_image()) {
-								tracing::error!("GPU color conversion failed: {e}");
+						let dmabuf_image = match dmabuf_image {
+							Ok(img) => img,
+							Err(e) => {
+								tracing::error!("Failed to import RGB DMA-BUF: {e}");
 								continue;
-							}
+							},
+						};
 
-							// Encode the converted image.
-							encoder.encode(encoder.input_image())
-						},
-						CapturePixelFormat::I420 => {
-							// I420 DMA-BUF - import and encode.
-							// Note: Encoder might need I420 support
-							tracing::warn!("I420 DMA-BUF not yet supported");
-							continue;
-						},
-					};
-
-					// Process encoded packets.
-					match encode_result {
-						Ok(packets) => {
-							for packet in packets {
-								if let Err(()) = self.send_packet(
-									&packet,
-									&packet_tx,
-									&mut packetizer,
-									&mut frame_number,
-									&mut sequence_number,
-								) {
-									tracing::error!("Failed to send encoded packet");
-									return Err("Failed to send packet".to_string());
+						// Initialize converter if needed.
+						let converter = match &mut color_converter {
+							Some(conv) => conv,
+							None => {
+								let config = ColorConverterConfig {
+									width: self.width,
+									height: self.height,
+									input_format,
+									output_format,
+								};
+								match ColorConverter::new(context.clone(), config) {
+									Ok(conv) => {
+										color_converter = Some(conv);
+										color_converter.as_mut().unwrap()
+									},
+									Err(e) => {
+										tracing::error!("Failed to create color converter: {e}");
+										continue;
+									},
 								}
-							}
-						},
-						Err(e) => {
-							tracing::error!("Failed to encode frame: {e}");
-						},
-					}
+							},
+						};
 
-					if !pending_idr {
-						last_frame_time = std::time::Instant::now();
-					}
+						// Convert RGB to YUV directly into the encoder's input image.
+						if let Err(e) = converter.convert(dmabuf_image.image(), encoder.input_image()) {
+							tracing::error!("GPU color conversion failed: {e}");
+							continue;
+						}
+
+						// Encode the converted image.
+						encoder.encode(encoder.input_image())
+					},
+					CapturePixelFormat::I420 => {
+						// I420 DMA-BUF - import and encode.
+						// Note: Encoder might need I420 support
+						tracing::warn!("I420 DMA-BUF not yet supported");
+						continue;
+					},
+				};
+
+				// Process encoded packets.
+				match encode_result {
+					Ok(packets) => {
+						for packet in packets {
+							if let Err(()) = self.send_packet(
+								&packet,
+								&packet_tx,
+								&mut packetizer,
+								&mut frame_number,
+								&mut sequence_number,
+							) {
+								tracing::error!("Failed to send encoded packet");
+								return Err("Failed to send packet".to_string());
+							}
+						}
+					},
+					Err(e) => {
+						tracing::error!("Failed to encode frame: {e}");
+					},
+				}
+
+				if !pending_idr {
+					last_frame_time = std::time::Instant::now();
 				}
 			}
+		}
 
 		// Wait for capture thread to finish (handled by CaptureHandle Drop)
 		drop(capture);

--- a/src/webserver/mod.rs
+++ b/src/webserver/mod.rs
@@ -64,7 +64,7 @@ impl Webserver {
 	pub fn new(
 		config: Config,
 		unique_id: String,
-        // Passing certificate content as string.
+		// Passing certificate content as string.
 		server_certs: String,
 		client_manager: ClientManager,
 		session_manager: SessionManager,
@@ -426,15 +426,15 @@ impl Webserver {
 		response += "<MaxLumaPixelsHEVC>1869449984</MaxLumaPixelsHEVC>"; // TODO: Check if HEVC is supported, set this to 0 if it is not.
 		response += "<LocalIP></LocalIP>";
 		let server_codec_mode_support = (ServerCodecModeSupport::H264 as u32)
-            | (ServerCodecModeSupport::H264High8444 as u32)
+			| (ServerCodecModeSupport::H264High8444 as u32)
 			| (ServerCodecModeSupport::Hevc as u32)
 			| (ServerCodecModeSupport::HevcRext8444 as u32)
 			| (ServerCodecModeSupport::HevcMain10 as u32)
 			| (ServerCodecModeSupport::HevcRext10444 as u32);
-			// | (ServerCodecModeSupport::Av1Main8 as u32)
-			// | (ServerCodecModeSupport::Av1High8444 as u32)
-			// | (ServerCodecModeSupport::Av1Main10 as u32)
-			// | (ServerCodecModeSupport::Av1High10444 as u32);
+		// | (ServerCodecModeSupport::Av1Main8 as u32)
+		// | (ServerCodecModeSupport::Av1High8444 as u32)
+		// | (ServerCodecModeSupport::Av1Main10 as u32)
+		// | (ServerCodecModeSupport::Av1High10444 as u32);
 		response += &format!(
 			"<ServerCodecModeSupport>{}</ServerCodecModeSupport>",
 			server_codec_mode_support

--- a/src/webserver/pairing.rs
+++ b/src/webserver/pairing.rs
@@ -81,16 +81,16 @@ async fn get_server_cert(
 			return bad_request(message);
 		},
 	};
-    
-    // PEM is expected to be a string
-    let client_pem = match String::from_utf8(client_cert) {
-        Ok(s) => s,
-        Err(e) => {
-            let message = format!("Failed to parse client cert as utf8: {e}");
-            tracing::warn!("{message}");
-            return bad_request(message);
-        }
-    };
+
+	// PEM is expected to be a string
+	let client_pem = match String::from_utf8(client_cert) {
+		Ok(s) => s,
+		Err(e) => {
+			let message = format!("Failed to parse client cert as utf8: {e}");
+			tracing::warn!("{message}");
+			return bad_request(message);
+		},
+	};
 
 	let unique_id = match params.remove("uniqueid") {
 		Some(unique_id) => unique_id,

--- a/src/webserver/tls.rs
+++ b/src/webserver/tls.rs
@@ -30,27 +30,29 @@ impl TlsAcceptor {
 }
 
 fn load_tls_files<P: AsRef<Path>>(certificate: P, private_key: P) -> Result<ServerConfig, ()> {
-    let certs = load_certs(certificate.as_ref())?;
-    let key = load_private_key(private_key.as_ref())?;
+	let certs = load_certs(certificate.as_ref())?;
+	let key = load_private_key(private_key.as_ref())?;
 
-    let config = ServerConfig::builder()
-        .with_no_client_auth()
-        .with_single_cert(certs, key)
-        .map_err(|e| tracing::error!("Failed to create TLS configuration: {}", e))?;
-    
-    Ok(config)
+	let config = ServerConfig::builder()
+		.with_no_client_auth()
+		.with_single_cert(certs, key)
+		.map_err(|e| tracing::error!("Failed to create TLS configuration: {}", e))?;
+
+	Ok(config)
 }
 
 fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>, ()> {
-    let mut reader = BufReader::new(File::open(path).map_err(|e| tracing::error!("Failed to open certificate file: {}", e))?);
-    rustls_pemfile::certs(&mut reader)
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| tracing::error!("Failed to load certificate: {}", e))
+	let mut reader =
+		BufReader::new(File::open(path).map_err(|e| tracing::error!("Failed to open certificate file: {}", e))?);
+	rustls_pemfile::certs(&mut reader)
+		.collect::<Result<Vec<_>, _>>()
+		.map_err(|e| tracing::error!("Failed to load certificate: {}", e))
 }
 
 fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, ()> {
-    let mut reader = BufReader::new(File::open(path).map_err(|e| tracing::error!("Failed to open private key file: {}", e))?);
-    rustls_pemfile::private_key(&mut reader)
-        .map_err(|e| tracing::error!("Failed to load private key: {}", e))?
-        .ok_or_else(|| tracing::error!("No private key found in file"))
+	let mut reader =
+		BufReader::new(File::open(path).map_err(|e| tracing::error!("Failed to open private key file: {}", e))?);
+	rustls_pemfile::private_key(&mut reader)
+		.map_err(|e| tracing::error!("Failed to load private key: {}", e))?
+		.ok_or_else(|| tracing::error!("No private key found in file"))
 }


### PR DESCRIPTION
:wave: This is part of a series of fixes I've produced while adding AV1 support to moonshine.

This one just runs `cargo fmt` - it seems like it hadn't been run in a while and I didn't want to clutter up all my other commits with a bunch of fmt changes mixed in making it more difficult to review.