### PR TITLE
compositor: add wp_viewporter for Wine/Proton Wayland compatibility

### DIFF
--- a/src/session/compositor/handlers.rs
+++ b/src/session/compositor/handlers.rs
@@ -15,6 +15,7 @@ use smithay::delegate_pointer_constraints;
 use smithay::delegate_relative_pointer;
 use smithay::delegate_seat;
 use smithay::delegate_shm;
+use smithay::delegate_viewporter;
 use smithay::delegate_xdg_shell;
 use smithay::delegate_xwayland_shell;
 use smithay::desktop::Window;
@@ -266,6 +267,7 @@ delegate_output!(MoonshineCompositor);
 delegate_relative_pointer!(MoonshineCompositor);
 delegate_pointer_constraints!(MoonshineCompositor);
 delegate_xwayland_shell!(MoonshineCompositor);
+delegate_viewporter!(MoonshineCompositor);
 
 // -- DMA-BUF Handler --
 

--- a/src/session/compositor/state.rs
+++ b/src/session/compositor/state.rs
@@ -250,6 +250,9 @@ pub struct MoonshineCompositor {
 	/// changes without a surface commit.
 	pub last_cursor_position: Point<f64, Logical>,
 
+	// -- Extended protocols --
+	pub viewporter_state: smithay::wayland::viewporter::ViewporterState,
+
 	// -- XWayland --
 	pub xwayland_shell_state: XWaylandShellState,
 	pub xwm: Option<X11Wm>,
@@ -303,6 +306,7 @@ impl MoonshineCompositor {
 		let xwayland_shell_state = XWaylandShellState::new::<Self>(&display_handle);
 		RelativePointerManagerState::new::<Self>(&display_handle);
 		PointerConstraintsState::new::<Self>(&display_handle);
+		let viewporter_state = smithay::wayland::viewporter::ViewporterState::new::<Self>(&display_handle);
 		let clock = Clock::new();
 
 		let mut space = Space::default();
@@ -419,6 +423,7 @@ impl MoonshineCompositor {
 				screen_dirty: true,
 				last_frame_sent_at: std::time::Instant::now(),
 				last_cursor_position: Point::from((width as f64 / 2.0, height as f64 / 2.0)),
+				viewporter_state,
 				xwayland_shell_state,
 				xwm: None,
 				xdisplay: None,


### PR DESCRIPTION
Allows Proton games to launch when PROTON_ENABLE_WAYLAND=1 is set. Wine's Wayland driver requires `wp_viewporter` at startup and refuses to initialize without it.