### PR TITLE
Fix surround sound (5.1/7.1) in PulseAudio virtual sink

### DIFF
--- a/src/session/stream/audio/pulse_server/commands.rs
+++ b/src/session/stream/audio/pulse_server/commands.rs
@@ -116,15 +116,26 @@ pub(super) fn handle_command(
 				return Ok(());
 			}
 
+			// When fix_channels is set, the client expects the stream to be fixed
+			// to the sink's channel configuration (used by winepulse for probing).
+			let (stream_spec, stream_channel_map) = if params.flags.fix_channels {
+				let mut fixed_spec = sample_spec;
+				fixed_spec.channels = server.capture_spec.channels;
+				let fixed_map = server.sinks[0].channel_map;
+				(fixed_spec, fixed_map)
+			} else {
+				(sample_spec, params.channel_map)
+			};
+
 			let mut buffer_attr = params.buffer_attr;
-			configure_buffer(&mut buffer_attr, &sample_spec);
+			configure_buffer(&mut buffer_attr, &stream_spec);
 
 			let target_length = buffer_attr.target_length;
 			let flags = params.flags;
 
 			let cvolume = params
 				.cvolume
-				.unwrap_or_else(|| pulse::ChannelVolume::norm(sample_spec.channels));
+				.unwrap_or_else(|| pulse::ChannelVolume::norm(stream_spec.channels));
 			let volume = cvolume_to_linear(&cvolume, server.capture_channels);
 			let muted = params.flags.start_muted == Some(true);
 
@@ -132,7 +143,7 @@ pub(super) fn handle_command(
 				stream_index: server.next_stream_index,
 				state: StreamState::Prebuffering(buffer_attr.pre_buffering as u64),
 				buffer_attr,
-				buffer: DynPlaybackBuffer::new(sample_spec, params.channel_map, server.capture_spec),
+				buffer: DynPlaybackBuffer::new(stream_spec, stream_channel_map, server.capture_spec),
 				volume,
 				muted,
 				requested_bytes: target_length as usize,
@@ -157,8 +168,8 @@ pub(super) fn handle_command(
 			let reply = pulse::CreatePlaybackStreamReply {
 				channel,
 				stream_index,
-				sample_spec,
-				channel_map: params.channel_map,
+				sample_spec: stream_spec,
+				channel_map: stream_channel_map,
 				buffer_attr,
 				requested_bytes: target_length,
 				sink_name: Some(sink_name),

--- a/src/session/stream/audio/pulse_server/mod.rs
+++ b/src/session/stream/audio/pulse_server/mod.rs
@@ -143,22 +143,53 @@ impl PulseServer {
 			sample_rate: CAPTURE_SAMPLE_RATE,
 		};
 
+		let channel_map = match channels {
+			6 => pulse::ChannelMap::new([
+				pulse::ChannelPosition::FrontLeft,
+				pulse::ChannelPosition::FrontRight,
+				pulse::ChannelPosition::FrontCenter,
+				pulse::ChannelPosition::Lfe,
+				pulse::ChannelPosition::RearLeft,
+				pulse::ChannelPosition::RearRight,
+			]),
+			8 => pulse::ChannelMap::new([
+				pulse::ChannelPosition::FrontLeft,
+				pulse::ChannelPosition::FrontRight,
+				pulse::ChannelPosition::FrontCenter,
+				pulse::ChannelPosition::Lfe,
+				pulse::ChannelPosition::RearLeft,
+				pulse::ChannelPosition::RearRight,
+				pulse::ChannelPosition::SideLeft,
+				pulse::ChannelPosition::SideRight,
+			]),
+			_ => pulse::ChannelMap::stereo(),
+		};
+
+		let port_name = match channels {
+			6 => "Surround 5.1 Output",
+			8 => "Surround 7.1 Output",
+			_ => "Stereo Output",
+		};
+
 		let mut dummy_sink = pulse::SinkInfo::new_dummy(1);
 		dummy_sink.name = sink_name.clone();
 		dummy_sink.description = Some(std::ffi::CString::new("Moonshine virtual output").unwrap());
 		dummy_sink.sample_spec = capture_spec;
+		dummy_sink.channel_map = channel_map;
+		dummy_sink.cvolume = pulse::ChannelVolume::norm(channels);
 
-		let mut server_info = pulse::ServerInfo {
+		let server_info = pulse::ServerInfo {
 			server_name: Some(std::ffi::CString::new("Moonshine").unwrap()),
 			server_version: Some(std::ffi::CString::new(env!("CARGO_PKG_VERSION")).unwrap()),
 			host_name: Some(std::ffi::CString::new("moonshine").unwrap()),
 			default_sink_name: Some(sink_name.clone()),
 			default_source_name: Some(sink_name),
 			sample_spec: capture_spec,
+			channel_map,
 			..Default::default()
 		};
-		server_info.channel_map = dummy_sink.channel_map;
 
+		dummy_sink.ports[0].name = std::ffi::CString::new(port_name).unwrap();
 		dummy_sink.ports[0].port_type = pulse::port_info::PortType::Network;
 		dummy_sink.ports[0].description = Some(std::ffi::CString::new("virtual output").unwrap());
 


### PR DESCRIPTION
## Summary

The virtual PulseAudio sink was always created with a stereo channel map, even when 5.1/7.1 surround was successfully negotiated via RTSP. This caused PulseAudio clients (notably Wine's `winepulse.drv`) to see only stereo output, preventing surround sound from working in games via Proton.

Two fixes:

- **Sink metadata**: set the sink's `channel_map`, `cvolume`, and port name based on the negotiated channel count. Previously, `SinkInfo::new_dummy()` defaults (stereo) were kept despite the `sample_spec` being updated to 6 or 8 channels.

- **`fix_channels` probe response**: when a client creates a playback stream with `fix_channels=true` (used by Wine's `winepulse.drv` to probe sink capabilities via `pulse_probe_settings`), respond with the sink's channel configuration instead of the requested one. This matches real PulseAudio behavior and allows Wine/Proton to correctly detect surround sound via WASAPI `GetMixFormat`.

## Test plan

- [x] Moonlight client configured for 5.1 surround connects and negotiates 6 channels
- [x] `pactl list sinks` shows correct 5.1 channel map and "Surround 5.1 Output" port
- [x] Wine/Proton games open 6-channel playback streams (verified via logs)
- [x] Surround sound output confirmed on 5.1 amplifier (Resident Evil via Proton)
- [x] Stereo fallback still works when client requests stereo
- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test` all pass