### PR TITLE
Fix missing boxart for Steam games and manual applications

### DIFF
--- a/src/app_scanner/desktop.rs
+++ b/src/app_scanner/desktop.rs
@@ -418,14 +418,14 @@ fn is_executable(path: &Path) -> bool {
 	}
 }
 
-struct IconResolver {
+pub(super) struct IconResolver {
 	enabled: bool,
 	cache: HashMap<String, Option<PathBuf>>,
 	search_roots: Vec<PathBuf>,
 }
 
 impl IconResolver {
-	fn new(enabled: bool) -> Self {
+	pub(super) fn new(enabled: bool) -> Self {
 		Self {
 			enabled,
 			cache: HashMap::new(),
@@ -470,7 +470,7 @@ impl IconResolver {
 		None
 	}
 
-	fn find_icon_by_name(&self, icon: &str) -> Option<PathBuf> {
+	pub(super) fn find_icon_by_name(&self, icon: &str) -> Option<PathBuf> {
 		let icon_stem = Path::new(icon)
 			.file_stem()
 			.and_then(|stem| stem.to_str())

--- a/src/app_scanner/mod.rs
+++ b/src/app_scanner/mod.rs
@@ -35,3 +35,13 @@ pub fn scan_applications(application_scanners: &Vec<ApplicationScannerConfig>) -
 
 	applications
 }
+
+/// Resolve missing boxart for applications by searching for icons matching the application title.
+pub fn resolve_missing_boxart(applications: &mut [ApplicationConfig]) {
+	let resolver = desktop::IconResolver::new(true);
+	for app in applications.iter_mut() {
+		if app.boxart.is_none() {
+			app.boxart = resolver.find_icon_by_name(&app.title.to_ascii_lowercase());
+		}
+	}
+}

--- a/src/app_scanner/steam.rs
+++ b/src/app_scanner/steam.rs
@@ -74,7 +74,9 @@ pub fn scan_steam_applications(config: &SteamApplicationScannerConfig) -> Result
 			.collect();
 
 		let game_dir = config.library.join(format!("appcache/librarycache/{game_id}/"));
-		if let Some(boxart) = search_file(&game_dir, "library_600x900.jpg") {
+		if let Some(boxart) =
+			search_file(&game_dir, "library_600x900.jpg").or_else(|| search_file(&game_dir, "library_capsule.jpg"))
+		{
 			if boxart.exists() {
 				application.boxart = Some(boxart);
 			} else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,8 @@ async fn main() -> Result<(), ()> {
 	tracing::debug!("Adding scanned applications:\n{:#?}", scanned_applications);
 	config.applications.extend(scanned_applications);
 
+	app_scanner::resolve_missing_boxart(&mut config.applications);
+
 	// Spawn a task to wait for CTRL+C and trigger a shutdown.
 	let shutdown = ShutdownManager::new();
 	tokio::spawn({


### PR DESCRIPTION
## Summary

- **Steam scanner**: fall back to `library_capsule.jpg` when `library_600x900.jpg` is not found. Recent Steam versions store game boxart in a new cache format using hashed subdirectories (e.g. `librarycache/{appid}/{hash}/library_capsule.jpg`) instead of `librarycache/{appid}/library_600x900.jpg`.

- **Missing boxart resolution**: applications without a `boxart` path (e.g. the default "Steam" entry) now get an icon resolved automatically from XDG icon directories, using the existing `IconResolver` from the desktop scanner.

## Test plan

- [x] Games using the new Steam cache format (library_capsule.jpg) now show boxart
- [x] Games using the old format (library_600x900.jpg) still work
- [x] The default "Steam" application gets an icon from system icons
- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test` all pass