### PR TITLE
fix: remove vk_engine_name from gamescope swapchain_feedback

### DIFF
--- a/src/session/compositor/gamescope_swapchain.rs
+++ b/src/session/compositor/gamescope_swapchain.rs
@@ -91,15 +91,9 @@ impl Dispatch<GamescopeSwapchain, SwapchainData> for MoonshineCompositor {
 			Request::SwapchainFeedback {
 				vk_colorspace,
 				vk_format,
-				vk_engine_name,
 				..
 			} => {
-				tracing::debug!(
-					vk_colorspace,
-					vk_format,
-					vk_engine_name,
-					"gamescope_swapchain::swapchain_feedback"
-				);
+				tracing::debug!(vk_colorspace, vk_format, "gamescope_swapchain::swapchain_feedback");
 
 				if let Some(cm) = &mut state.color_management {
 					if vk_colorspace == VK_COLOR_SPACE_HDR10_ST2084_EXT {

--- a/src/session/compositor/protocols/gamescope-swapchain.xml
+++ b/src/session/compositor/protocols/gamescope-swapchain.xml
@@ -89,7 +89,6 @@
       <arg name="vk_composite_alpha" type="uint" summary="VkCompositeAlphaFlagBitsKHR of swapchain"/>
       <arg name="vk_pre_transform" type="uint" summary="VkSurfaceTransformFlagBitsKHR of swapchain"/>
       <arg name="vk_clipped" type="uint" summary="clipped (VkBool32) of swapchain"/>
-      <arg name="vk_engine_name" type="string" summary="Engine name"/>
     </request>
 
     <request name="set_present_mode">


### PR DESCRIPTION
The gamescope WSI layer shipped on Bazzite (bazzite-org/gamescope tag ba147) sends swapchain_feedback with 6 arguments. Upstream ValveSoftware/gamescope added vk_engine_name as a 7th argument (6a4d150) without bumping the protocol version, but this change has not been merged into the Bazzite fork.

The argument count mismatch causes wayland-server to reject the request, resulting in a black screen on launch.

Moonshine does not use vk_engine_name. The 6-arg form is wire-compatible with 7-arg clients (extra data is silently skipped by the wayland message parser).

Fixes #41