### PR TITLE
fix: enable Wayland-native apps to bind to the embedded compositor's socket

### DIFF
--- a/src/app_scanner/desktop.rs
+++ b/src/app_scanner/desktop.rs
@@ -94,7 +94,12 @@ fn parse_desktop_application(
 
 	let boxart = icon_resolver.resolve(entry.icon().map(str::trim).filter(|icon| !icon.is_empty()), path);
 
-	Ok(Some(ApplicationConfig { title, boxart, command }))
+	Ok(Some(ApplicationConfig {
+		title,
+		boxart,
+		command,
+		wayland_native: false,
+	}))
 }
 
 #[derive(Debug, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,7 @@ impl Default for Config {
 				title: "Steam".to_string(),
 				command: vec!["/usr/bin/steam".to_string(), "steam://open/bigpicture".to_string()],
 				boxart: None,
+				wayland_native: false,
 			}],
 			application_scanners: vec![ApplicationScannerConfig::Steam(SteamApplicationScannerConfig {
 				library: "$HOME/.local/share/Steam".into(),
@@ -133,6 +134,12 @@ pub struct ApplicationConfig {
 
 	/// The command to run.
 	pub command: Vec<String>,
+
+	/// Whether the application is Wayland-native and should have
+	/// WAYLAND_DISPLAY set when launched. When false (default),
+	/// WAYLAND_DISPLAY is unset to force X11 via XWayland.
+	#[serde(default = "default_false")]
+	pub wayland_native: bool,
 }
 
 impl ApplicationConfig {

--- a/src/session/compositor/mod.rs
+++ b/src/session/compositor/mod.rs
@@ -53,6 +53,8 @@ pub struct CompositorReady {
 	pub xdisplay: u32,
 	/// Wayland socket name for the gamescope WSI layer (only set when HDR is active).
 	pub gamescope_wayland_display: Option<String>,
+	/// Wayland socket name for the main compositor.
+	pub wayland_display: String,
 }
 
 /// Result type for `start_compositor`.

--- a/src/session/compositor/state.rs
+++ b/src/session/compositor/state.rs
@@ -295,6 +295,9 @@ pub struct MoonshineCompositor {
 	/// Wayland socket name for the gamescope WSI layer (only set when HDR is active).
 	pub gamescope_wayland_display: Option<String>,
 
+	/// Wayland socket name for the main compositor.
+	pub wayland_display: String,
+
 	// -- Gamescope WSI layer --
 	/// Override surface from gamescope_swapchain::override_window_content.
 	/// When set, this surface is rendered instead of the original X11 window.
@@ -408,6 +411,7 @@ impl MoonshineCompositor {
 		} else {
 			None
 		};
+		let wayland_display = socket_name.to_string_lossy().into_owned();
 
 		// Register the socket source with the event loop.
 		let mut display_handle_clone = display_handle.clone();
@@ -527,6 +531,7 @@ impl MoonshineCompositor {
 				xdisplay: None,
 				xdisplay_tx: Some(xdisplay_tx),
 				gamescope_wayland_display,
+				wayland_display,
 				override_surface: None,
 				x11_input_conn: None,
 				focused_x11_window: None,
@@ -1131,6 +1136,7 @@ impl MoonshineCompositor {
 						let _ = tx.send(super::CompositorReady {
 							xdisplay: display_number,
 							gamescope_wayland_display: data.gamescope_wayland_display.clone(),
+							wayland_display: data.wayland_display.clone(),
 						});
 					}
 				},

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -351,10 +351,15 @@ fn launch_application(
 	.arg(program)
 	.args(args)
 	.env("PULSE_SERVER", format!("unix:{}", socket_path.display()))
-	.env("DISPLAY", format!(":{}", ready.xdisplay))
-	// Remove WAYLAND_DISPLAY so the game uses X11 via DISPLAY,
-	// and the gamescope WSI layer only needs GAMESCOPE_WAYLAND_DISPLAY.
-	.env_remove("WAYLAND_DISPLAY");
+	.env("DISPLAY", format!(":{}", ready.xdisplay));
+
+	// Conditionally set WAYLAND_DISPLAY based on application config.
+	// Wayland-native apps (e.g., Waydroid) need this; games typically use X11.
+	if context.application.wayland_native {
+		cmd.env("WAYLAND_DISPLAY", ready.wayland_display.clone());
+	} else {
+		cmd.env_remove("WAYLAND_DISPLAY");
+	}
 
 	// Pass gamescope WSI env vars directly to the child process.
 	if let Some(ref gamescope_display) = ready.gamescope_wayland_display {


### PR DESCRIPTION
A possible fix to #50

I do not know much about Wayland, so I went with the assumption that Smithay not cleaning up sockets is a best practice to avoid racing conditions and so on. Under that assumption, it is best to leave current code mostly unchanged and simply add a `wayland_native`  boolean field to  `ApplicationConfig`  that tells whether the application is Wayland-native and thus controls whether  `WAYLAND_DISPLAY`  should be set or unset when launching that specific application. Defaults to  `false`  for backward compatibility. The rest of the code changes merely follow from that decision.

Config example:
```toml
[[application]]
title = "Waydroid"
command = ["/usr/bin/waydroid", "show-full-ui"]
wayland_native = true
```

Scanned applications have `wayland_native = false` for now, since this feature is mostly used to populate entries from the installed Steam Library. May need to rethink it if other use cases come up.