### PR TITLE
feat: enable service to start without graphical session

### DIFF
--- a/dist/moonshine.service
+++ b/dist/moonshine.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Streaming server using the NVIDIA GameStream / Moonlight protocol.
-PartOf=graphical-session.target
-Wants=graphical-session.target
-After=graphical-session.target
+After=multi-user.target
 
 [Service]
 ExecStart=/usr/bin/moonshine %E/moonshine/config.toml
@@ -10,4 +8,4 @@ Environment=RUST_LOG=info
 Restart=always
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target


### PR DESCRIPTION
A trivial solution to #53
Here proposed is a replacement to `moonshine.service`, but this could be just as easily made into another file called `moonshine-headless.service`, for example.