### PR TITLE
feat: make requiring/verifying client certs optional

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -104,6 +104,22 @@ pub struct WebserverConfig {
 	#[serde(default = "default_true")]
 	pub enable_pairing: bool,
 
+	/// Whether to require client certificates for HTTPS endpoints.
+	///
+	/// When enabled (the default), HTTPS endpoints (/launch, /resume, /cancel, /applist, /appasset)
+	/// require a valid client certificate from a paired client. Disable this for compatibility
+	/// with clients that do not support mTLS.
+	#[serde(default = "default_true")]
+	pub require_client_cert: bool,
+
+	/// Whether to enforce strict X.509 v3 certificate verification.
+	///
+	/// When enabled (the default), only X.509 v3 certificates are accepted. Disable this to
+	/// accept older X.509 v2 certificates (e.g., from moonlight-tv). This bypasses TLS-level
+	/// signature verification for client certificates.
+	#[serde(default = "default_true")]
+	pub strict_cert_verification: bool,
+
 	/// Path to the certificate for SSL encryption.
 	pub certificate: PathBuf,
 
@@ -117,6 +133,8 @@ impl Default for WebserverConfig {
 			port: 47989,
 			port_https: 47984,
 			enable_pairing: true,
+			require_client_cert: true,
+			strict_cert_verification: true,
 			certificate: "$HOME/.config/moonshine/cert.pem".into(),
 			private_key: "$HOME/.config/moonshine/key.pem".into(),
 		}

--- a/src/webserver/mod.rs
+++ b/src/webserver/mod.rs
@@ -193,8 +193,11 @@ impl Webserver {
 						let listener = TcpListener::bind(https_address)
 							.await
 							.map_err(|e| tracing::error!("Failed to bind to address '{:?}': {e}", https_address))?;
-						let acceptor =
-							TlsAcceptor::from_config(config.webserver.certificate, config.webserver.private_key)?;
+						let acceptor = TlsAcceptor::from_config(
+							config.webserver.certificate,
+							config.webserver.private_key,
+							config.webserver.strict_cert_verification,
+						)?;
 
 						tracing::debug!("HTTPS server listening for connections on {https_address}");
 						loop {
@@ -898,6 +901,10 @@ impl Webserver {
 	/// that belongs to a paired client. Returns `None` if authorized,
 	/// or `Some(response)` with a 401 response if not.
 	async fn verify_paired_client(&self, peer_cert_fingerprint: &Option<String>) -> Option<Response<Full<Bytes>>> {
+		if !self.config.webserver.require_client_cert {
+			return None;
+		}
+
 		match peer_cert_fingerprint {
 			Some(fingerprint) => match self.client_manager.is_cert_paired(fingerprint).await {
 				Ok(true) => None,

--- a/src/webserver/tls.rs
+++ b/src/webserver/tls.rs
@@ -23,15 +23,17 @@ use tokio_rustls::{server::TlsStream, TlsAcceptor as TlsAcceptorTokio};
 /// during pairing) can still connect.
 struct AllowAnyClientCert {
 	supported_algs: WebPkiSupportedAlgorithms,
+	strict_verification: bool,
 }
 
 impl AllowAnyClientCert {
-	fn new() -> Self {
+	fn new(strict_verification: bool) -> Self {
 		let provider = CryptoProvider::get_default()
 			.cloned()
 			.unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
 		Self {
 			supported_algs: provider.signature_verification_algorithms,
+			strict_verification,
 		}
 	}
 }
@@ -71,7 +73,12 @@ impl ClientCertVerifier for AllowAnyClientCert {
 		cert: &CertificateDer<'_>,
 		dss: &DigitallySignedStruct,
 	) -> Result<HandshakeSignatureValid, Error> {
-		verify_tls12_signature(message, cert, dss, &self.supported_algs)
+		if self.strict_verification {
+			verify_tls12_signature(message, cert, dss, &self.supported_algs)
+		} else {
+			// Skip signature verification for compatibility with X.509 v2 certificates
+			Ok(HandshakeSignatureValid::assertion())
+		}
 	}
 
 	fn verify_tls13_signature(
@@ -80,7 +87,12 @@ impl ClientCertVerifier for AllowAnyClientCert {
 		cert: &CertificateDer<'_>,
 		dss: &DigitallySignedStruct,
 	) -> Result<HandshakeSignatureValid, Error> {
-		verify_tls13_signature(message, cert, dss, &self.supported_algs)
+		if self.strict_verification {
+			verify_tls13_signature(message, cert, dss, &self.supported_algs)
+		} else {
+			// Skip signature verification for compatibility with X.509 v2 certificates
+			Ok(HandshakeSignatureValid::assertion())
+		}
 	}
 
 	fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
@@ -93,8 +105,12 @@ pub struct TlsAcceptor {
 }
 
 impl TlsAcceptor {
-	pub fn from_config<P: AsRef<Path>>(certificate: P, private_key: P) -> Result<Self, ()> {
-		let config = load_tls_files(certificate, private_key)?;
+	pub fn from_config<P: AsRef<Path>>(
+		certificate: P,
+		private_key: P,
+		strict_verification: bool,
+	) -> Result<Self, ()> {
+		let config = load_tls_files(certificate, private_key, strict_verification)?;
 		let acceptor = TlsAcceptorTokio::from(Arc::new(config));
 		Ok(Self { acceptor })
 	}
@@ -109,12 +125,16 @@ impl TlsAcceptor {
 	}
 }
 
-fn load_tls_files<P: AsRef<Path>>(certificate: P, private_key: P) -> Result<ServerConfig, ()> {
+fn load_tls_files<P: AsRef<Path>>(
+	certificate: P,
+	private_key: P,
+	strict_verification: bool,
+) -> Result<ServerConfig, ()> {
 	let certs = load_certs(certificate.as_ref())?;
 	let key = load_private_key(private_key.as_ref())?;
 
 	let config = ServerConfig::builder()
-		.with_client_cert_verifier(Arc::new(AllowAnyClientCert::new()))
+		.with_client_cert_verifier(Arc::new(AllowAnyClientCert::new(strict_verification)))
 		.with_single_cert(certs, key)
 		.map_err(|e| tracing::error!("Failed to create TLS configuration: {}", e))?;
 

--- a/src/webserver/tls.rs
+++ b/src/webserver/tls.rs
@@ -105,11 +105,7 @@ pub struct TlsAcceptor {
 }
 
 impl TlsAcceptor {
-	pub fn from_config<P: AsRef<Path>>(
-		certificate: P,
-		private_key: P,
-		strict_verification: bool,
-	) -> Result<Self, ()> {
+	pub fn from_config<P: AsRef<Path>>(certificate: P, private_key: P, strict_verification: bool) -> Result<Self, ()> {
 		let config = load_tls_files(certificate, private_key, strict_verification)?;
 		let acceptor = TlsAcceptorTokio::from(Arc::new(config));
 		Ok(Self { acceptor })


### PR DESCRIPTION
A possible fix to #52 

The rationale was to make the security enhancements introduced in moonshine v0.9.0 optional via configuration parameters. 

Added two configuration parameters to `WebserverConfig`, which default to `true`:
 
```toml
[webserver]
# Whether to require client certificates for HTTPS endpoints.
# When enabled (the default), HTTPS endpoints require a valid client certificate 
# from a paired client. Disable this for compatibility with clients that do not 
# support mTLS.
require_client_cert = true
 
# Whether to enforce strict X.509 v3 certificate verification.
# When enabled (the default), only X.509 v3 certificates are accepted. Disable 
# this to accept older X.509 v2 certificates (e.g., from moonlight-tv). This 
# bypasses TLS-level signature verification for client certificates.
strict_cert_verification = true
```

Perhaps both parameters should default to `false`? 
(so that first time users get a "smooth" experience with any client, while those who need the extra security will surely be able to find these options in the docs)

I tested this on my LG TV with `require_client_cert = true` and `strict_cert_verification = false`, and the Aurora client was able to connect to moonshine again.