### PR TITLE
fix: add PULSE_RUNTIME_PATH env var for Waydroid compatibility

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -351,7 +351,10 @@ fn launch_application(
 	.arg(program)
 	.args(args)
 	.env("PULSE_SERVER", format!("unix:{}", socket_path.display()))
-	.env("PULSE_RUNTIME_PATH", socket_path.parent().unwrap().display().to_string())
+	.env(
+		"PULSE_RUNTIME_PATH",
+		socket_path.parent().unwrap().display().to_string(),
+	)
 	.env("DISPLAY", format!(":{}", ready.xdisplay))
 	// Remove WAYLAND_DISPLAY so the game uses X11 via DISPLAY,
 	// and the gamescope WSI layer only needs GAMESCOPE_WAYLAND_DISPLAY.


### PR DESCRIPTION
Fixes #56 

This change sets both PULSE_SERVER and PULSE_RUNTIME_PATH when launching applications, ensuring compatibility with both traditional PulseAudio clients and apps that use the alternative method like Waydroid.