### PR TITLE
fix: enlarge target fill level of the pulseaudio playback buffer

### DIFF
--- a/src/session/stream/audio/pulse_server/commands.rs
+++ b/src/session/stream/audio/pulse_server/commands.rs
@@ -531,14 +531,14 @@ fn configure_buffer(attr: &mut pulse::stream::BufferAttr, spec: &pulse::SampleSp
 	}
 
 	if attr.target_length == u32::MAX {
-		attr.target_length = (len_10ms * 2)
+		attr.target_length = (len_10ms * 6)
 			.next_multiple_of(attr.minimum_request_length)
 			.min(attr.max_length);
 	} else {
 		attr.target_length = attr
 			.target_length
 			.next_multiple_of(attr.minimum_request_length)
-			.max(len_10ms)
+			.max(len_10ms * 6)
 			.min(attr.max_length);
 
 		if attr.target_length < (attr.minimum_request_length * 2) {


### PR DESCRIPTION
Fixes #58

The Waydroid audio HAL requires ~10-20ms to respond to PulseAudio's `PA_COMMAND_REQUEST` events. Moonshine's default target fill level of the pulseaudio playback buffer (`target_length`) of 20ms was insufficient - the buffer would drain to zero before the audio HAL could respond to requests.

**Timeline of failure:**
```
0ms  - Audio HAL connects, writes 8,188 bytes
5-25ms - Buffer drains at 960 bytes/5ms, no requests sent yet
30ms - First PA_REQUEST sent (1,668 bytes needed)
35-40ms - Audio HAL still hasn't responded
45ms - Buffer empty, underrun occurs
```

After the buffer underrun occurs, sound stops working for the remainder of the streaming session. Some video playing apps freeze (waiting for sound to sync with image), other apps (notably VLC and Chrome) play silently.

The solution was to set a higher value for `target_length`. The new value of 60ms was determined by iterative testing of 10ms increments from the initial value of 20ms. Several tests where performed where video playing apps played correctly with sound for over one hour without any freezes or sound cuts.