### PR TITLE
fix: change udev rules to work with headless service

### DIFF
--- a/dist/60-moonshine.rules
+++ b/dist/60-moonshine.rules
@@ -1,2 +1,2 @@
-KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", TAG+="uaccess"
-KERNEL=="uhid", TAG+="uaccess"
+KERNEL=="uinput", SUBSYSTEM=="misc", OPTIONS+="static_node=uinput", GROUP="input", MODE="0660"
+KERNEL=="uhid", OPTIONS+="static_node=uhid", GROUP="input", MODE="0660"


### PR DESCRIPTION
Fixes `udev` rules following merge of #54

The solution entails changing from a "uaccess tag" approach to a "group-based access" approach.
The `uaccess udev` tag mechanism only grants device access to users in sessions with seat assignment, but the service runs in a session which has no seat assigned. Group-based access, on the other hand, doesn't depend on seat assignment. The `input` group is already trusted for input devices and can be reused for this purpose.

For this solution to work the user (under which the `moonshine.service` runs) needs to be in the `input` group: `sudo usermod -aG input <username>`. Perhaps this should be added to the package manager install script. 
(Btw, another prerequisite and a discussion not had regarding #54: the user needs to have linger enabled, otherwise the service will not start until the user logs in, defeating the purpose making the service headless: `sudo loginctl enable-linger <username>`)

A alternative solution would consist in using the more recent `xaccess` concept introduced in systemd 256, but such a solution was not explored due to higher complexity.