### PR TITLE
fix: steam app scanner handle multiple steam libraries

### DIFF
--- a/src/app_scanner/steam.rs
+++ b/src/app_scanner/steam.rs
@@ -7,6 +7,75 @@ use walkdir::WalkDir;
 
 use crate::config::{ApplicationConfig, SteamApplicationScannerConfig};
 
+struct LibraryFolder {
+	path: PathBuf,
+	apps: Vec<u32>,
+}
+
+fn parse_vdf(vdf_content: &str) -> Vec<LibraryFolder> {
+	let library_folder_depth = 2;
+	let apps_depth = 3;
+	let path_pattern = "\"path\"";
+	let mut library_folders = Vec::new();
+	let mut current_path: Option<PathBuf> = None;
+	let mut current_apps: Vec<u32> = Vec::new();
+	let mut depth = 0;
+
+	for line in vdf_content.lines().map(|l| l.trim()) {
+		if line == "{" {
+			depth += 1;
+			continue;
+		}
+		if line == "}" {
+			depth -= 1;
+
+			// if we go back to depth 1, it means we finished parsing lib folder block
+			if depth == 1 {
+				if let Some(path) = current_path.take() {
+					// adding folder to list
+					library_folders.push(LibraryFolder {
+						path,
+						apps: std::mem::take(&mut current_apps),
+					});
+				}
+			}
+			continue;
+		}
+
+		// library_folder depth
+		// this block contains folder path
+		if depth == library_folder_depth && line.starts_with(path_pattern) {
+			if let Some(start_quote) = &line[path_pattern.len()..].find('"') {
+				let path_start = path_pattern.len() + start_quote + 1;
+
+				if let Some(end_quote) = line[path_start..].find('"') {
+					let path_str = &line[path_start..path_start + end_quote];
+					let parsed_path = PathBuf::from(path_str);
+
+					current_path = Some(parsed_path);
+				}
+			}
+
+		// apps list depth
+		} else if depth == apps_depth && line.starts_with('"') {
+			// game line: "game_id" "_"
+			if let Some(id_end) = &line[1..].find('"') {
+				let id_str = &line[1..1 + id_end];
+				let parsed_id: u32 = match id_str.parse() {
+					Ok(id) => id,
+					Err(e) => {
+						tracing::warn!("Failed to parse game id, {e}");
+						continue;
+					},
+				};
+				current_apps.push(parsed_id);
+			}
+		}
+	}
+
+	library_folders
+}
+
 pub fn scan_steam_applications(config: &SteamApplicationScannerConfig) -> Result<Vec<ApplicationConfig>, ()> {
 	let library_path = config
 		.library
@@ -19,94 +88,67 @@ pub fn scan_steam_applications(config: &SteamApplicationScannerConfig) -> Result
 	let library =
 		std::fs::read_to_string(library_path.as_ref()).map_err(|e| tracing::warn!("Failed to open library: {e}"))?;
 
+	let library_folders = parse_vdf(&library);
+
 	// Poor man's library parsing.
-	let start_apps = library
-		.find("apps")
-		.ok_or_else(|| tracing::warn!("Failed to find 'apps' key in {library_path:?}."))?;
-	let library = &library[start_apps..];
-	let stop_apps = library
-		.find('}')
-		.ok_or_else(|| tracing::warn!("Failed to find end of 'apps' section."))?;
-	let library = &library[..stop_apps];
+	let applications: Vec<ApplicationConfig> = library_folders
+		.into_iter()
+		.flat_map(|folder| {
+			let folder_path = folder.path.clone();
 
-	let mut applications = Vec::new();
-	for line in library.lines().skip(2) {
-		let mut application = ApplicationConfig { ..Default::default() };
+			folder.apps.into_iter().filter_map(move |app_id| {
+				let mut application = ApplicationConfig { ..Default::default() };
 
-		if line.trim().is_empty() {
-			continue;
-		}
+				let steamapps_dir = folder_path.join("steamapps");
+				if let Ok(title) = get_game_name(app_id, &steamapps_dir) {
+					application.title = title;
+				} else {
+					tracing::warn!("Could not get name of application '{app_id}'");
+					return None;
+				}
 
-		let game_id = match line.split('\"').nth(1) {
-			Some(game_id) => game_id,
-			None => {
-				tracing::warn!("Failed to parse library entry: '{line}'");
-				continue;
-			},
-		};
+				// skip things that aren't really games.
+				if application.title.starts_with("Proton")
+					|| application.title.starts_with("Steam Linux Runtime")
+					|| application.title.starts_with("Steamworks Common Redistributables")
+				{
+					return None;
+				}
 
-		let game_id: u32 = match game_id.parse() {
-			Ok(game_id) => game_id,
-			Err(e) => {
-				tracing::warn!("Failed to parse game id: {e}");
-				continue;
-			},
-		};
+				application.command = config
+					.command
+					.clone()
+					.iter()
+					.map(|a| a.replace("{game_id}", &app_id.to_string()))
+					.collect();
 
-		application.title = match get_game_name(game_id, library_path.as_ref()) {
-			Ok(title) => title,
-			Err(()) => continue,
-		};
+				let game_dir = config.library.join(format!("appcache/librarycache/{app_id}/"));
+				if let Some(boxart) = search_file(&game_dir, "library_600x900.jpg")
+					.or_else(|| search_file(&game_dir, "library_capsule.jpg"))
+				{
+					if boxart.exists() {
+						application.boxart = Some(boxart);
+					} else {
+						tracing::warn!("No boxart for game '{}' at '{}.", application.title, boxart.display());
+					}
+				} else {
+					tracing::debug!(
+						"No boxart found for game '{}' in directory '{}'.",
+						application.title,
+						game_dir.display()
+					);
+				}
 
-		// Skip things that aren't really games.
-		if application.title.starts_with("Proton")
-			|| application.title.starts_with("Steam Linux Runtime")
-			|| application.title.starts_with("Steamworks Common Redistributables")
-		{
-			continue;
-		}
-
-		application.command = config
-			.command
-			.clone()
-			.iter()
-			.map(|a| a.replace("{game_id}", &game_id.to_string()))
-			.collect();
-
-		let game_dir = config.library.join(format!("appcache/librarycache/{game_id}/"));
-		if let Some(boxart) =
-			search_file(&game_dir, "library_600x900.jpg").or_else(|| search_file(&game_dir, "library_capsule.jpg"))
-		{
-			if boxart.exists() {
-				application.boxart = Some(boxart);
-			} else {
-				tracing::warn!("No boxart for game '{}' at '{}.", application.title, boxart.display());
-			}
-		} else {
-			tracing::debug!(
-				"No boxart found for game '{}' in directory '{}'.",
-				application.title,
-				game_dir.display()
-			);
-		}
-
-		applications.push(application);
-	}
+				Some(application)
+			})
+		})
+		.collect();
 
 	Ok(applications)
 }
 
-fn get_game_name<P: AsRef<Path>>(game_id: u32, library: P) -> Result<String, ()> {
-	let manifest_path = library
-		.as_ref()
-		.parent()
-		.ok_or_else(|| {
-			eprintln!(
-				"Expected '{:?}' to have a parent, but couldn't find one.",
-				library.as_ref()
-			)
-		})?
-		.join(format!("appmanifest_{}.acf", game_id));
+fn get_game_name<P: AsRef<Path>>(game_id: u32, steamapps_dir: P) -> Result<String, ()> {
+	let manifest_path = steamapps_dir.as_ref().join(format!("appmanifest_{}.acf", game_id));
 	let manifest = std::fs::read_to_string(&manifest_path)
 		.map_err(|e| eprintln!("Failed to open Steam game manifest ({manifest_path:?}): {e}"))?;
 	let name_line = manifest.lines().find(|l| l.contains("\"name\""));


### PR DESCRIPTION
- Added a new struct that represents a simplified LibraryFolder
- Added a parser function that generates a vector of LibraryFolder
- Changed the get_game_name function to use the steamapps_dir folder given in argument