### PR TITLE
fix: swap chain detection for games that don't use vkSetHdrMetadataEXT

### DIFF
--- a/moonshine-wsi/src/swapchain.rs
+++ b/moonshine-wsi/src/swapchain.rs
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn create_swapchain(
 	// compositor signals HDR support; otherwise pass the app's create-info
 	// through unchanged so the ICD can handle its own color management.
 	let layer_hdr_active = instance_key
-		.and_then(|ik| get_wayland_connection(ik))
+		.and_then(get_wayland_connection)
 		.map(|arc| arc.force_lock().caps.hdr_supported)
 		.unwrap_or(false);
 	let need_remap = layer_hdr_active && app_color_space != ash::vk::ColorSpaceKHR::SRGB_NONLINEAR;

--- a/src/session/compositor/gamescope_swapchain.rs
+++ b/src/session/compositor/gamescope_swapchain.rs
@@ -38,18 +38,43 @@ pub struct SwapchainData {
 /// Common swapchain feedback handling.
 fn handle_swapchain_feedback(
 	state: &mut MoonshineCompositor,
-	_surface: &WlSurface,
+	surface: &WlSurface,
 	vk_colorspace: u32,
 	vk_format: u32,
 ) -> (u32, u32) {
 	tracing::debug!(vk_colorspace, vk_format, "swapchain_feedback");
 
-	// NOTE: We intentionally do NOT set Bt2020Pq here based on the swapchain
-	// color space alone.  DXVK with DXVK_HDR=1 creates HDR swapchains even
-	// for SDR games, so the color space in the swapchain create info doesn't
-	// mean the game is actually outputting PQ data.  We defer the HDR switch
-	// to handle_set_hdr_metadata(), which fires only when the game calls
-	// vkSetHdrMetadataEXT — a reliable signal that the game is truly doing HDR.
+	// Set HDR mode based on swapchain color space.  When the swapchain uses
+	// HDR10_ST2084 (1000104008), the game is outputting PQ-encoded data.
+	// When it switches back to sRGB (0), clear HDR state.
+	// Some games (e.g. Monster Hunter Wilds) never call vkSetHdrMetadataEXT
+	// and rely solely on the swapchain color space to signal HDR.
+	const VK_COLOR_SPACE_SRGB_NONLINEAR: u32 = 0;
+	const VK_COLOR_SPACE_HDR10_ST2084_EXT: u32 = 1000104008;
+
+	if let Some(cm) = &mut state.color_management {
+		match vk_colorspace {
+			VK_COLOR_SPACE_HDR10_ST2084_EXT => {
+				tracing::info!("swapchain_feedback: HDR10_ST2084 detected, activating HDR");
+				cm.set_gamescope_current(
+					surface,
+					super::color_management::ImageDescription {
+						transfer_function: super::color_management::TransferFunction::St2084Pq,
+						primaries: super::color_management::Primaries::Bt2020,
+						max_cll: None,
+						max_fall: None,
+						mastering_luminance: None,
+						mastering_primaries: None,
+						white_point: None,
+					},
+				);
+			},
+			VK_COLOR_SPACE_SRGB_NONLINEAR => {
+				cm.clear_gamescope_current(surface);
+			},
+			_ => {},
+		}
+	}
 
 	// Compute the refresh cycle to return to the WSI layer.
 	let refresh_ns = state

--- a/src/session/compositor/state.rs
+++ b/src/session/compositor/state.rs
@@ -8,6 +8,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
 use std::sync::Arc;
 
+use smithay::reexports::wayland_server::Resource;
+
 use smithay::backend::allocator::dmabuf::{AsDmabuf, Dmabuf};
 use smithay::backend::allocator::gbm::GbmAllocator;
 use smithay::backend::allocator::{Allocator, Buffer, Fourcc, Modifier};
@@ -332,14 +334,22 @@ pub struct MoonshineCompositor {
 
 	// -- Direct scanout --
 	/// Client buffers held alive during direct scanout until the encoder
-	/// signals `consumed`. Each entry pairs a consumed flag, the DMA-BUF
-	/// fd numbers (for `scanout_fd_map` cleanup), and the cloned Smithay
+	/// signals `consumed`. Each entry pairs a consumed flag, the wl_buffer
+	/// ObjectId (for `scanout_buffer_map` cleanup), and the cloned Smithay
 	/// `Buffer` (keeps wl_buffer from being released).
-	held_scanout_buffers: Vec<(Arc<AtomicBool>, Vec<i32>, smithay::backend::renderer::utils::Buffer)>,
-	/// Maps DMA-BUF fd numbers to stable buffer indices for the encoder's
-	/// import cache. Indices start at `BUFFER_POOL_SIZE` to avoid collisions
-	/// with the GBM pool.
-	scanout_fd_map: std::collections::HashMap<i32, usize>,
+	held_scanout_buffers: Vec<(
+		Arc<AtomicBool>,
+		smithay::reexports::wayland_server::backend::ObjectId,
+		smithay::backend::renderer::utils::Buffer,
+	)>,
+	/// Maps wl_buffer ObjectIds to stable buffer indices for pixelforge's
+	/// dmabuf import cache. Keying by ObjectId is robust against protocols
+	/// that re-duplicate fds per commit (e.g. gamescope_swapchain via
+	/// vkd3d-proton); fd-keying produces fresh indices each frame and
+	/// effectively bypasses the cache. Indices start at `BUFFER_POOL_SIZE`
+	/// to avoid collisions with the GBM pool.
+	scanout_buffer_map:
+		std::collections::HashMap<smithay::reexports::wayland_server::backend::ObjectId, usize>,
 	/// Next available scanout buffer index.
 	scanout_next_index: usize,
 }
@@ -541,7 +551,7 @@ impl MoonshineCompositor {
 				pid_app_id_cache: std::collections::HashMap::new(),
 				x11_focus_needs_reset: false,
 				held_scanout_buffers: Vec::new(),
-				scanout_fd_map: std::collections::HashMap::new(),
+				scanout_buffer_map: std::collections::HashMap::new(),
 				scanout_next_index: BUFFER_POOL_SIZE,
 			},
 			display,
@@ -563,12 +573,11 @@ impl MoonshineCompositor {
 		}
 
 		// Release held scanout buffers that the encoder has finished reading.
-		// Remove their FDs from the map so recycled FDs get fresh indices.
-		self.held_scanout_buffers.retain(|(consumed, fds, _)| {
+		// Drop their entries from the buffer→index map; if the same wl_buffer
+		// is re-attached later it'll get a fresh index.
+		self.held_scanout_buffers.retain(|(consumed, buffer_id, _)| {
 			if consumed.load(Ordering::Acquire) {
-				for fd in fds {
-					self.scanout_fd_map.remove(fd);
-				}
+				self.scanout_buffer_map.remove(buffer_id);
 				false
 			} else {
 				true
@@ -925,13 +934,11 @@ impl MoonshineCompositor {
 			return false;
 		}
 
-		// Assign a stable buffer index for the encoder's import cache.
-		let fds: Vec<i32> = client_dmabuf
-			.handles()
-			.map(|h: std::os::unix::io::BorrowedFd<'_>| h.as_raw_fd())
-			.collect();
-		let fd = fds.first().copied().unwrap_or(-1);
-		let buffer_index = *self.scanout_fd_map.entry(fd).or_insert_with(|| {
+		// Assign a stable buffer index for the encoder's import cache, keyed
+		// by the wl_buffer's ObjectId (stable across re-attaches of the same
+		// buffer regardless of how the protocol handles fd duplication).
+		let buffer_id = buffer.id();
+		let buffer_index = *self.scanout_buffer_map.entry(buffer_id.clone()).or_insert_with(|| {
 			let idx = self.scanout_next_index;
 			self.scanout_next_index += 1;
 			idx
@@ -973,7 +980,7 @@ impl MoonshineCompositor {
 		};
 
 		// Hold the client Buffer alive until the encoder finishes reading.
-		self.held_scanout_buffers.push((consumed.clone(), fds, buffer));
+		self.held_scanout_buffers.push((consumed.clone(), buffer_id, buffer));
 
 		match self.frame_tx.try_send(exported_frame) {
 			Err(mpsc::TrySendError::Disconnected(_)) => {
@@ -1071,14 +1078,19 @@ impl MoonshineCompositor {
 			return false;
 		}
 
-		let fds: Vec<i32> = client_dmabuf
-			.handles()
-			.map(|h: std::os::unix::io::BorrowedFd<'_>| h.as_raw_fd())
-			.collect();
-		let fd = fds.first().copied().unwrap_or(-1);
-		let buffer_index = *self.scanout_fd_map.entry(fd).or_insert_with(|| {
+		let buffer_id = buffer.id();
+		let buffer_index = *self.scanout_buffer_map.entry(buffer_id.clone()).or_insert_with(|| {
 			let idx = self.scanout_next_index;
 			self.scanout_next_index += 1;
+			tracing::debug!(
+				buffer_index = self.scanout_next_index - 1,
+				fourcc = ?client_dmabuf.format().code,
+				modifier = format!("{:#x}", Into::<u64>::into(client_dmabuf.format().modifier)).as_str(),
+				num_planes = client_dmabuf.num_planes(),
+				width = client_dmabuf.width(),
+				height = client_dmabuf.height(),
+				"Override scanout: importing new buffer",
+			);
 			idx
 		});
 
@@ -1117,7 +1129,7 @@ impl MoonshineCompositor {
 			hdr_metadata,
 		};
 
-		self.held_scanout_buffers.push((consumed.clone(), fds, buffer));
+		self.held_scanout_buffers.push((consumed.clone(), buffer_id, buffer));
 
 		match self.frame_tx.try_send(exported_frame) {
 			Err(mpsc::TrySendError::Disconnected(_)) => {

--- a/src/session/compositor/state.rs
+++ b/src/session/compositor/state.rs
@@ -576,10 +576,21 @@ impl MoonshineCompositor {
 		});
 
 		// Try direct scanout: bypass compositor rendering when a single
-		// fullscreen DMA-BUF surface covers the entire output.
-		// Skip when the WSI layer has an active override surface for the
-		// currently focused window, as that surface needs frame callbacks.
-		if !self.is_override_active() && self.try_direct_scanout() {
+		// fullscreen DMA-BUF surface covers the entire output. This avoids
+		// the compositor's GLES blit, which otherwise competes with the
+		// game on the gfx queue and inflates per-frame encode latency at
+		// GPU saturation.
+		//
+		// When the WSI layer has an active override surface, scanout from
+		// the override's wl_surface (the gamescope_swapchain image) and
+		// deliver frame callbacks to it. Otherwise scanout from the lone
+		// space toplevel as before.
+		if self.is_override_active() {
+			if self.try_direct_scanout_override() {
+				tracing::trace!("Frame via direct scanout (override path)");
+				return;
+			}
+		} else if self.try_direct_scanout() {
 			tracing::trace!("Frame via direct scanout (not override path)");
 			return;
 		}
@@ -1010,6 +1021,152 @@ impl MoonshineCompositor {
 
 		if let Err(e) = self.display_handle.flush_clients() {
 			tracing::error!("Failed to flush clients after scanout: {e}");
+		}
+
+		true
+	}
+
+	/// Direct DMA-BUF scanout for the gamescope/moonshine override surface.
+	///
+	/// When the WSI layer has installed an override surface (gamescope_swapchain
+	/// or moonshine_swapchain protocol), the game's frames are committed to
+	/// `self.override_surface` rather than to a space toplevel. Without this
+	/// path the compositor falls back to a GLES blit on the gfx queue, which
+	/// competes with the game's rendering at GPU saturation and inflates encode
+	/// latency. This sends the override surface's committed DMA-BUF straight
+	/// to the encoder and delivers frame callbacks to the override surface so
+	/// the WSI layer's `vkQueuePresentKHR` can unblock for the next frame.
+	fn try_direct_scanout_override(&mut self) -> bool {
+		let override_surface = match self.override_surface.as_ref() {
+			Some((s, _)) if s.alive() => s.clone(),
+			_ => return false,
+		};
+
+		let scanout_buffer = with_renderer_surface_state(&override_surface, |state| {
+			let buffer = state.buffer()?;
+			if !matches!(smithay::backend::renderer::buffer_type(buffer), Some(BufferType::Dma)) {
+				tracing::trace!("Override scanout: buffer is not DMA-BUF");
+				return None;
+			}
+			Some(buffer.clone())
+		});
+		let Some(Some(buffer)) = scanout_buffer else {
+			tracing::trace!("Override scanout: no committed buffer");
+			return false;
+		};
+		let Ok(client_dmabuf) = dmabuf::get_dmabuf(&buffer) else {
+			tracing::trace!("Override scanout: failed to get DMA-BUF from buffer");
+			return false;
+		};
+		let client_dmabuf = client_dmabuf.clone();
+
+		if client_dmabuf.width() != self.width || client_dmabuf.height() != self.height {
+			tracing::trace!(
+				"Override scanout: size mismatch (client {}x{} vs output {}x{})",
+				client_dmabuf.width(),
+				client_dmabuf.height(),
+				self.width,
+				self.height,
+			);
+			return false;
+		}
+
+		let fds: Vec<i32> = client_dmabuf
+			.handles()
+			.map(|h: std::os::unix::io::BorrowedFd<'_>| h.as_raw_fd())
+			.collect();
+		let fd = fds.first().copied().unwrap_or(-1);
+		let buffer_index = *self.scanout_fd_map.entry(fd).or_insert_with(|| {
+			let idx = self.scanout_next_index;
+			self.scanout_next_index += 1;
+			idx
+		});
+
+		let consumed = Arc::new(AtomicBool::new(false));
+
+		let color_space = self
+			.color_management
+			.as_ref()
+			.map(|cm| cm.frame_color_space())
+			.unwrap_or(FrameColorSpace::Srgb);
+		let hdr_metadata = self.color_management.as_ref().and_then(|cm| cm.hdr_metadata());
+
+		let planes: Vec<ExportedPlane> = client_dmabuf
+			.handles()
+			.zip(client_dmabuf.offsets())
+			.zip(client_dmabuf.strides())
+			.map(
+				|((handle, offset), stride): ((std::os::unix::io::BorrowedFd<'_>, u32), u32)| ExportedPlane {
+					fd: handle.as_raw_fd(),
+					offset,
+					stride,
+				},
+			)
+			.collect();
+
+		let exported_frame = ExportedFrame {
+			planes,
+			format: client_dmabuf.format().code as u32,
+			modifier: Into::<u64>::into(client_dmabuf.format().modifier),
+			width: client_dmabuf.width(),
+			height: client_dmabuf.height(),
+			created_at: std::time::Instant::now(),
+			buffer_index,
+			consumed: consumed.clone(),
+			color_space,
+			hdr_metadata,
+		};
+
+		self.held_scanout_buffers.push((consumed.clone(), fds, buffer));
+
+		match self.frame_tx.try_send(exported_frame) {
+			Err(mpsc::TrySendError::Disconnected(_)) => {
+				tracing::debug!("Frame channel disconnected, compositor stopping.");
+			},
+			Err(mpsc::TrySendError::Full(_)) => {
+				consumed.store(true, Ordering::Release);
+			},
+			Ok(()) => {
+				self.screen_dirty = false;
+				self.last_frame_sent_at = std::time::Instant::now();
+			},
+		}
+
+		// Frame callbacks must go to the override surface (the game's WSI
+		// layer is waiting on these to unblock vkQueuePresentKHR). Without
+		// this the game would block forever after the first frame.
+		send_frames_surface_tree(
+			&override_surface,
+			&self.output,
+			self.clock.now(),
+			Some(std::time::Duration::ZERO),
+			|_, _| Some(self.output.clone()),
+		);
+
+		let mut feedback = OutputPresentationFeedback::new(&self.output);
+		take_presentation_feedback_surface_tree(
+			&override_surface,
+			&mut feedback,
+			|_, _| Some(self.output.clone()),
+			|_, _| {
+				smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::empty()
+			},
+		);
+		let frame_period = self
+			.output
+			.preferred_mode()
+			.map(|m| std::time::Duration::from_nanos(1_000_000_000_000u64 / m.refresh.max(1) as u64))
+			.unwrap_or(std::time::Duration::from_millis(11));
+		feedback.presented::<smithay::utils::Time<Monotonic>, Monotonic>(
+			self.clock.now(),
+			Refresh::Fixed(frame_period),
+			0,
+			smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::empty(
+			),
+		);
+
+		if let Err(e) = self.display_handle.flush_clients() {
+			tracing::error!("Failed to flush clients after override scanout: {e}");
 		}
 
 		true

--- a/src/session/stream/video/pipeline/dmabuf.rs
+++ b/src/session/stream/video/pipeline/dmabuf.rs
@@ -153,7 +153,10 @@ impl DmaBufImporter {
 		});
 		let evicted = before - self.cache.len();
 		if evicted > 0 {
-			trace!("DmaBufImporter: evicted {evicted} stale cache entries, {} live", self.cache.len());
+			trace!(
+				"DmaBufImporter: evicted {evicted} stale cache entries, {} live",
+				self.cache.len()
+			);
 		}
 	}
 

--- a/src/session/stream/video/pipeline/dmabuf.rs
+++ b/src/session/stream/video/pipeline/dmabuf.rs
@@ -7,12 +7,31 @@
 //! so that pre-allocated GBM buffers are imported only once. Subsequent frames
 //! from the same buffer reuse the cached `VkImage` and `VkDeviceMemory`,
 //! eliminating per-frame Vulkan object creation and layout transitions.
+//!
+//! The cache evicts entries that have not been touched in `CACHE_TTL`. During
+//! real-game streaming, gamescope assigns monotonically-growing `buffer_index`
+//! values (~76/sec at 120 fps), so without eviction the cache (and its backing
+//! VRAM) would grow unboundedly across a session. With TTL eviction, only the
+//! actively-cycling buffers stay resident; old indexes are reclaimed.
 
 use ash::vk;
 use pixelforge::VideoContext;
+use std::collections::HashMap;
 use std::os::fd::RawFd;
 use std::os::unix::io::{BorrowedFd, IntoRawFd};
-use tracing::debug;
+use std::time::{Duration, Instant};
+use tracing::{debug, trace};
+
+/// How long a cached import stays resident after its last use before being
+/// evicted and freed. Long enough that any in-flight encoder/blitter work
+/// using the image has definitely completed (depth-2 pipeline at 120 fps is
+/// ~16 ms of in-flight latency), short enough that monotonically-growing
+/// buffer-index churn doesn't accumulate VRAM.
+const CACHE_TTL: Duration = Duration::from_secs(2);
+
+/// Sweep for stale cache entries every N `import_or_reuse` calls. Cheap
+/// (HashMap retain over a small map) but no point doing it every frame.
+const SWEEP_INTERVAL_CALLS: u32 = 60;
 
 /// Information about a single DMA-BUF plane.
 #[derive(Debug, Clone, Copy)]
@@ -31,18 +50,23 @@ pub struct DmaBufPlane {
 struct CachedImport {
 	image: vk::Image,
 	memory: vk::DeviceMemory,
+	last_used: Instant,
 }
 
 /// Importer for DMA-BUF file descriptors into Vulkan images.
 ///
-/// Owns a per-buffer-index cache of `VkImage` + `VkDeviceMemory`.
-/// Layout transitions are deferred to the consumer (e.g. `ColorConverter`)
-/// to avoid a separate GPU submission per first-time import.
+/// Owns a per-buffer-index cache of `VkImage` + `VkDeviceMemory` with TTL
+/// eviction. Layout transitions are deferred to the consumer
+/// (e.g. `ColorConverter`/`RgbBlitter`) to avoid a separate GPU submission
+/// per first-time import.
 pub struct DmaBufImporter {
 	context: VideoContext,
 	external_memory_fd: ash::khr::external_memory_fd::Device,
-	/// Per-buffer-index cache. Index corresponds to `ExportedFrame::buffer_index`.
-	cached_imports: Vec<Option<CachedImport>>,
+	/// Per-buffer-index cache. Switched from `Vec<Option<…>>` to a HashMap so
+	/// monotonically-growing `buffer_index` values don't grow a sparse Vec.
+	cache: HashMap<usize, CachedImport>,
+	/// Calls since the last stale-entry sweep.
+	calls_since_sweep: u32,
 }
 
 impl DmaBufImporter {
@@ -53,7 +77,8 @@ impl DmaBufImporter {
 		Ok(Self {
 			context,
 			external_memory_fd,
-			cached_imports: Vec::new(),
+			cache: HashMap::new(),
+			calls_since_sweep: 0,
 		})
 	}
 
@@ -76,12 +101,15 @@ impl DmaBufImporter {
 		format: vk::Format,
 		planes: &[DmaBufPlane],
 	) -> Result<(vk::Image, bool), String> {
-		// Grow the cache vector if needed.
-		if self.cached_imports.len() <= buffer_index {
-			self.cached_imports.resize_with(buffer_index + 1, || None);
+		self.calls_since_sweep += 1;
+		if self.calls_since_sweep >= SWEEP_INTERVAL_CALLS {
+			self.calls_since_sweep = 0;
+			self.evict_stale();
 		}
 
-		if let Some(cached) = &self.cached_imports[buffer_index] {
+		let now = Instant::now();
+		if let Some(cached) = self.cache.get_mut(&buffer_index) {
+			cached.last_used = now;
 			return Ok((cached.image, false));
 		}
 
@@ -93,8 +121,40 @@ impl DmaBufImporter {
 
 		let (image, memory) = self.import_internal(width, height, format, planes)?;
 
-		self.cached_imports[buffer_index] = Some(CachedImport { image, memory });
+		self.cache.insert(
+			buffer_index,
+			CachedImport {
+				image,
+				memory,
+				last_used: now,
+			},
+		);
 		Ok((image, true))
+	}
+
+	/// Drop cached entries that haven't been touched in `CACHE_TTL` and free
+	/// their backing Vulkan resources. Stale entries are guaranteed to be out
+	/// of any encoder/blitter pipeline (TTL >> max in-flight depth at 120 fps),
+	/// so it's safe to destroy without an explicit fence wait.
+	fn evict_stale(&mut self) {
+		let cutoff = Instant::now() - CACHE_TTL;
+		let device = self.context.device();
+		let before = self.cache.len();
+		self.cache.retain(|_, v| {
+			if v.last_used < cutoff {
+				unsafe {
+					device.destroy_image(v.image, None);
+					device.free_memory(v.memory, None);
+				}
+				false
+			} else {
+				true
+			}
+		});
+		let evicted = before - self.cache.len();
+		if evicted > 0 {
+			trace!("DmaBufImporter: evicted {evicted} stale cache entries, {} live", self.cache.len());
+		}
 	}
 
 	/// Perform the raw Vulkan import of a DMA-BUF with the specified format.
@@ -225,8 +285,7 @@ impl Drop for DmaBufImporter {
 	fn drop(&mut self) {
 		let device = self.context.device();
 		unsafe {
-			// Clean up cached imports.
-			for cached in self.cached_imports.drain(..).flatten() {
+			for (_, cached) in self.cache.drain() {
 				device.destroy_image(cached.image, None);
 				device.free_memory(cached.memory, None);
 			}

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -33,13 +33,22 @@ fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
 	// DRM fourcc values (from drm_fourcc.h):
 	// ARGB8888 = 0x34325241, XRGB8888 = 0x34325258
 	// ABGR8888 = 0x34324241, XBGR8888 = 0x34324258
-	// ABGR2101010 = 0x30334241
+	// ABGR2101010 = 0x30334241, XBGR2101010 = 0x30334258
+	// ARGB2101010 = 0x30335241, XRGB2101010 = 0x30335258
 	// ABGR16161616F = 0x48344241
+	//
+	// X-variants share the same bit layout as their A-counterparts; the
+	// alpha bits are simply ignored. vkd3d-proton's swapchain typically
+	// allocates XBGR2101010 (XB30) for HDR — treating that as the BGRx
+	// fallback (8-bit BGRA) produces rainbow corruption when 10-bit
+	// packed data is read as 8-bit channels.
 	match fourcc {
 		0x34324241 | 0x34324258 => (InputFormat::RGBA, vk::Format::R8G8B8A8_UNORM), // ABGR/XBGR8888
-		0x30334241 => (InputFormat::ABGR2101010, vk::Format::A2B10G10R10_UNORM_PACK32), // ABGR2101010
-		0x48344241 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT),      // ABGR16161616F
-		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM),                       // ARGB/XRGB8888 (fallback)
+		0x30334241 | 0x30334258 => {
+			(InputFormat::ABGR2101010, vk::Format::A2B10G10R10_UNORM_PACK32) // ABGR/XBGR 2101010
+		},
+		0x48344241 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT), // ABGR16161616F
+		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM), // ARGB/XRGB8888 (fallback)
 	}
 }
 

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -48,7 +48,7 @@ fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
 			(InputFormat::ABGR2101010, vk::Format::A2B10G10R10_UNORM_PACK32) // ABGR/XBGR 2101010
 		},
 		0x48344241 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT), // ABGR16161616F
-		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM), // ARGB/XRGB8888 (fallback)
+		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM),                  // ARGB/XRGB8888 (fallback)
 	}
 }
 


### PR DESCRIPTION
Fixes HDR not activating for games that signal HDR via swapchain colorspace instead of vkSetHdrMetadataEXT. For me, this was happening in MH Wilds, moonshine would always just start the stream and stay in SDR mode regardless of how the game HDR setting was set. It's a bit of an odd case since it doesn't have an explicit toggle for "hdr on" it's either "automatic" or "disabled". I think unfortunately different game engines are all over the place with how they signal HDR :(

also rolled in a few related things from the same investigation that cut host processing latency for games that use vkd3d-proton (RE engine games primarily) by a significant amount:

- Direct DMA-BUF scanout. The compositor was incorrectly taking the override surface into its own buffer which resulted in resource contention with the game rendering buffer if the GPU is fully saturated. 
- Caching for imported DMA-BUFs by wl_buffer ObjectId. Some games using vkd3d-proton (DXVK's d3d12 layer) create a fresh wl_buffer per frame instead of reusing a pool, so the cache keying strategy always missed, resulting in expensive operations for every frame trashing the host rendering performance. This doesn't seem to happen on D3D11, opengl, or vulkan games at all. Again, I was able to cause this with MH Wilds and Pragmata, but as far as I know any RE Engine title from within the last ~5 years should be impacted.
- Map XBGR2101010 / XRGB2101010 fourcc to10-bit input format. With direct scanout, this bug surfaces at 10-bit override-surface frames getting treated as 8-bit and producing classic "rainbow" corruption in HDR. caught while debugging the HDR detect issue.

This should be something that you can recreate by A/B testing streaming an RE engine game. Before and host rendering performance should be significantly improved, and HDR detection should also work properly. You may need to crank game settings to max and turn off frame gen/DLSS/FSR to get a significant enough GPU load to see the performance issues, depending on your GPU.