### PR TITLE
feat: add pre/post cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ command = ["/usr/bin/steam", "steam://open/bigpicture"]
 - `title`: The name shown in Moonlight.
 - `boxart` (optional): Path to a cover image.
 - `command`: The command to run. First entry is the executable, the rest are arguments.
+- `pre_command` (optional): Commands to run before launching the application. Each entry is a separate command, executed in order. Runs synchronously — the session waits for all to finish.
+- `post_command` (optional): Commands to run after the streaming session ends. Each entry is a separate command, executed in order. Runs synchronously — the server waits for all to finish.
+
+Example:
+
+```toml
+[[application]]
+title = "Steam"
+command = ["/usr/bin/steam", "steam://open/bigpicture"]
+pre_command = [
+    ["/usr/bin/systemctl", "stop", "conflicting.service"],
+    ["/usr/bin/nvidia-smi", "pstate", "50"],
+]
+post_command = [
+    ["/usr/bin/nvidia-smi", "pstate", "performance"],
+]
+```
 
 ### Application scanners
 

--- a/src/app_scanner/desktop.rs
+++ b/src/app_scanner/desktop.rs
@@ -94,7 +94,12 @@ fn parse_desktop_application(
 
 	let boxart = icon_resolver.resolve(entry.icon().map(str::trim).filter(|icon| !icon.is_empty()), path);
 
-	Ok(Some(ApplicationConfig { title, boxart, command }))
+	Ok(Some(ApplicationConfig {
+		title,
+		boxart,
+		command,
+		..Default::default()
+	}))
 }
 
 #[derive(Debug, Default)]

--- a/src/app_scanner/steam.rs
+++ b/src/app_scanner/steam.rs
@@ -31,7 +31,11 @@ pub fn scan_steam_applications(config: &SteamApplicationScannerConfig) -> Result
 
 	let mut applications = Vec::new();
 	for line in library.lines().skip(2) {
-		let mut application = ApplicationConfig { ..Default::default() };
+		let mut application = ApplicationConfig {
+			pre_command: config.pre_command.clone(),
+			post_command: config.post_command.clone(),
+			..Default::default()
+		};
 
 		if line.trim().is_empty() {
 			continue;

--- a/src/config.rs
+++ b/src/config.rs
@@ -146,7 +146,7 @@ pub struct ApplicationConfig {
 
 	/// Commands to run after the streaming session ends.
 	/// Each inner Vec is a separate command; they execute in order.
-	/// Runs in the background — moonshine does not wait for them to finish.
+	/// Runs synchronously — the server waits for all to finish before accepting new connections.
 	/// Useful for restoring system state (e.g. GPU power management).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub post_command: Vec<Vec<String>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,17 +137,19 @@ pub struct ApplicationConfig {
 	/// The command to run.
 	pub command: Vec<String>,
 
-	/// Command to run before launching the application.
-	/// Runs synchronously — the application launch waits for it to finish.
+	/// Commands to run before launching the application.
+	/// Each inner Vec is a separate command; they execute in order.
+	/// Runs synchronously — the application launch waits for all to finish.
 	/// Useful for killing conflicting processes, setting GPU power states, etc.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub pre_command: Vec<String>,
+	pub pre_command: Vec<Vec<String>>,
 
-	/// Command to run after the streaming session ends.
-	/// Runs in the background — moonshine does not wait for it to finish.
+	/// Commands to run after the streaming session ends.
+	/// Each inner Vec is a separate command; they execute in order.
+	/// Runs in the background — moonshine does not wait for them to finish.
 	/// Useful for restoring system state (e.g. GPU power management).
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub post_command: Vec<String>,
+	pub post_command: Vec<Vec<String>>,
 }
 
 impl ApplicationConfig {
@@ -177,13 +179,13 @@ pub struct SteamApplicationScannerConfig {
 	/// The command to run.
 	pub command: Vec<String>,
 
-	/// Command to run before launching each scanned application.
+	/// Commands to run before launching each scanned application.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub pre_command: Vec<String>,
+	pub pre_command: Vec<Vec<String>>,
 
-	/// Command to run after each scanned application's session ends.
+	/// Commands to run after each scanned application's session ends.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub post_command: Vec<String>,
+	pub post_command: Vec<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,7 @@ impl Default for Config {
 				title: "Steam".to_string(),
 				command: vec!["/usr/bin/steam".to_string(), "steam://open/bigpicture".to_string()],
 				boxart: None,
+				..Default::default()
 			}],
 			application_scanners: vec![ApplicationScannerConfig::Steam(SteamApplicationScannerConfig {
 				library: "$HOME/.local/share/Steam".into(),
@@ -84,6 +85,8 @@ impl Default for Config {
 					"-bigpicture".to_string(),
 					"steam://rungameid/{game_id}".to_string(),
 				],
+				pre_command: Vec::new(),
+				post_command: Vec::new(),
 			})],
 			gpu: None,
 			hdr_support: true,
@@ -133,6 +136,18 @@ pub struct ApplicationConfig {
 
 	/// The command to run.
 	pub command: Vec<String>,
+
+	/// Command to run before launching the application.
+	/// Runs synchronously — the application launch waits for it to finish.
+	/// Useful for killing conflicting processes, setting GPU power states, etc.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub pre_command: Vec<String>,
+
+	/// Command to run after the streaming session ends.
+	/// Runs in the background — moonshine does not wait for it to finish.
+	/// Useful for restoring system state (e.g. GPU power management).
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub post_command: Vec<String>,
 }
 
 impl ApplicationConfig {
@@ -161,6 +176,14 @@ pub struct SteamApplicationScannerConfig {
 
 	/// The command to run.
 	pub command: Vec<String>,
+
+	/// Command to run before launching each scanned application.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub pre_command: Vec<String>,
+
+	/// Command to run after each scanned application's session ends.
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub post_command: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -189,6 +189,8 @@ impl SessionInner {
 					if let Err(e) = std::thread::Builder::new().name("app-launcher".to_string()).spawn(
 						move || -> Result<Child, ()> {
 							let result = (|| -> Result<Child, ()> {
+								run_hook("pre_command", &app_context.application.pre_command);
+
 								let ready = ready_rx
 									.recv_timeout(std::time::Duration::from_secs(5))
 									.map_err(|e| tracing::warn!("Timed out waiting for XWayland display: {e}"))?;
@@ -301,7 +303,37 @@ impl SessionInner {
 			.stderr(Stdio::null())
 			.status();
 
+		run_hook("post_command", &session_context.application.post_command);
+
 		tracing::debug!("Session stopped.");
+	}
+}
+
+/// Run a configured hook command, logging the result.
+/// Skips silently if the command is empty.
+fn run_hook(name: &str, command: &[String]) {
+	if command.is_empty() {
+		return;
+	}
+
+	let Some(program) = command.first() else {
+		return;
+	};
+	let args = &command[1..];
+
+	tracing::info!("{name}: running {:?}", command);
+	match Command::new(program)
+		.args(args)
+		.stdout(Stdio::null())
+		.stderr(Stdio::null())
+		.status()
+	{
+		Ok(status) => {
+			if !status.success() {
+				tracing::warn!("{name}: exited with {status}");
+			}
+		},
+		Err(e) => tracing::warn!("{name}: failed to run: {e}"),
 	}
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -309,31 +309,33 @@ impl SessionInner {
 	}
 }
 
-/// Run a configured hook command, logging the result.
-/// Skips silently if the command is empty.
-fn run_hook(name: &str, command: &[String]) {
-	if command.is_empty() {
-		return;
-	}
+/// Run configured hook commands, logging the result of each.
+/// Commands are executed in order; skips silently if the list is empty.
+fn run_hook(name: &str, commands: &[Vec<String>]) {
+	for (i, command) in commands.iter().enumerate() {
+		if command.is_empty() {
+			continue;
+		}
 
-	let Some(program) = command.first() else {
-		return;
-	};
-	let args = &command[1..];
+		let Some(program) = command.first() else {
+			continue;
+		};
+		let args = &command[1..];
 
-	tracing::info!("{name}: running {:?}", command);
-	match Command::new(program)
-		.args(args)
-		.stdout(Stdio::null())
-		.stderr(Stdio::null())
-		.status()
-	{
-		Ok(status) => {
-			if !status.success() {
-				tracing::warn!("{name}: exited with {status}");
-			}
-		},
-		Err(e) => tracing::warn!("{name}: failed to run: {e}"),
+		tracing::info!("{name}[{i}]: running {:?}", command);
+		match Command::new(program)
+			.args(args)
+			.stdout(Stdio::null())
+			.stderr(Stdio::null())
+			.status()
+		{
+			Ok(status) => {
+				if !status.success() {
+					tracing::warn!("{name}[{i}]: exited with {status}");
+				}
+			},
+			Err(e) => tracing::warn!("{name}[{i}]: failed to run: {e}"),
+		}
 	}
 }
 


### PR DESCRIPTION
- Adds the ability for arbitrary `pre_command` and `post_command` that can be run before/after and defined for each different application types in `config.toml`
- Example: `pre_command = ["pkill", "-x", "steam"] ` to kill existing steam instances before starting steam-based streaming targets