### PR TITLE
Add supersampling support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -226,6 +226,12 @@ pub struct VideoStreamConfig {
 	/// the messages can be very noisy.
 	#[serde(default = "default_false")]
 	pub log_frame_spikes: bool,
+
+	/// List of client resolutions (width, height) that will be rendered at 2× and
+	/// downscaled before encoding. Empty list disables supersampling entirely.
+	/// Example: `supersampled_resolutions = [[1280, 800], [1920, 1080]]`
+	#[serde(default)]
+	pub supersampled_resolutions: Vec<[u32; 2]>,
 }
 
 impl Default for VideoStreamConfig {
@@ -235,6 +241,7 @@ impl Default for VideoStreamConfig {
 			fec_percentage: 20,
 			encrypt: false,
 			log_frame_spikes: false,
+			supersampled_resolutions: Vec::new(),
 		}
 	}
 }

--- a/src/rtsp.rs
+++ b/src/rtsp.rs
@@ -360,6 +360,8 @@ impl RtspServer {
 		let video_stream_context = VideoStreamContext {
 			width,
 			height,
+			render_width: 0,
+			render_height: 0,
 			fps,
 			packet_size,
 			bitrate,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -165,9 +165,12 @@ impl SessionInner {
 					// Start the headless compositor with HDR format selection
 					// based on the negotiated dynamic range.
 					let hdr = video_stream_context.dynamic_range == VideoDynamicRange::Hdr;
+					let (encode_w, encode_h) = (session_context.resolution.0, session_context.resolution.1);
+					let supersample = self.config.stream.video.supersampled_resolutions.contains(&[encode_w, encode_h]);
+					let (render_w, render_h) = if supersample { (encode_w * 2, encode_h * 2) } else { (encode_w, encode_h) };
 					let compositor_config = compositor::CompositorConfig {
-						width: session_context.resolution.0,
-						height: session_context.resolution.1,
+						width: render_w,
+						height: render_h,
 						refresh_rate: session_context._refresh_rate,
 						gpu: self.config.gpu.clone(),
 						hdr,
@@ -221,6 +224,9 @@ impl SessionInner {
 						metadata: None,
 					});
 
+					let mut video_stream_context = video_stream_context;
+					video_stream_context.render_width = render_w;
+					video_stream_context.render_height = render_h;
 					let video_stream = match VideoStream::new(
 						self.config.clone(),
 						video_stream_context.clone(),

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -166,8 +166,17 @@ impl SessionInner {
 					// based on the negotiated dynamic range.
 					let hdr = video_stream_context.dynamic_range == VideoDynamicRange::Hdr;
 					let (encode_w, encode_h) = (session_context.resolution.0, session_context.resolution.1);
-					let supersample = self.config.stream.video.supersampled_resolutions.contains(&[encode_w, encode_h]);
-					let (render_w, render_h) = if supersample { (encode_w * 2, encode_h * 2) } else { (encode_w, encode_h) };
+					let supersample = self
+						.config
+						.stream
+						.video
+						.supersampled_resolutions
+						.contains(&[encode_w, encode_h]);
+					let (render_w, render_h) = if supersample {
+						(encode_w * 2, encode_h * 2)
+					} else {
+						(encode_w, encode_h)
+					};
 					let compositor_config = compositor::CompositorConfig {
 						width: render_w,
 						height: render_h,

--- a/src/session/stream/video/mod.rs
+++ b/src/session/stream/video/mod.rs
@@ -82,6 +82,9 @@ enum VideoStreamCommand {
 pub struct VideoStreamContext {
 	pub width: u32,
 	pub height: u32,
+	/// Compositor render resolution — equals width/height unless supersampling is active.
+	pub render_width: u32,
+	pub render_height: u32,
 	pub fps: u32,
 	pub packet_size: usize,
 	pub bitrate: usize,
@@ -238,6 +241,8 @@ impl VideoStreamInner {
 			frame_rx,
 			self.context.width,
 			self.context.height,
+			self.context.render_width,
+			self.context.render_height,
 			self.context.fps,
 			self.context.bitrate,
 			self.context.packet_size,

--- a/src/session/stream/video/pipeline/downsample.rs
+++ b/src/session/stream/video/pipeline/downsample.rs
@@ -1,0 +1,284 @@
+use ash::vk;
+use pixelforge::VideoContext;
+
+pub struct Downsampler {
+	context: VideoContext,
+	dst_image: vk::Image,
+	dst_memory: vk::DeviceMemory,
+	command_pool: vk::CommandPool,
+	command_buffer: vk::CommandBuffer,
+	fence: vk::Fence,
+	src_width: u32,
+	src_height: u32,
+	dst_width: u32,
+	dst_height: u32,
+	vk_format: vk::Format,
+}
+
+impl Downsampler {
+	pub fn new(
+		context: VideoContext,
+		src_width: u32,
+		src_height: u32,
+		dst_width: u32,
+		dst_height: u32,
+		vk_format: vk::Format,
+	) -> Result<Self, String> {
+		let device = context.device();
+
+		// Verify the format supports blit source and destination.
+		let format_props = unsafe {
+			context
+				.instance()
+				.get_physical_device_format_properties(context.physical_device(), vk_format)
+		};
+		let required = vk::FormatFeatureFlags::BLIT_DST;
+		let optimal_features = format_props.optimal_tiling_features;
+		if !optimal_features.contains(required) {
+			return Err(format!(
+				"Format {vk_format:?} does not support BLIT_DST (features: {optimal_features:?})"
+			));
+		}
+
+		// Create destination image at encode resolution.
+		let image_info = vk::ImageCreateInfo::default()
+			.image_type(vk::ImageType::TYPE_2D)
+			.format(vk_format)
+			.extent(vk::Extent3D { width: dst_width, height: dst_height, depth: 1 })
+			.mip_levels(1)
+			.array_layers(1)
+			.samples(vk::SampleCountFlags::TYPE_1)
+			.tiling(vk::ImageTiling::OPTIMAL)
+			.usage(vk::ImageUsageFlags::TRANSFER_DST | vk::ImageUsageFlags::TRANSFER_SRC | vk::ImageUsageFlags::SAMPLED)
+			.sharing_mode(vk::SharingMode::EXCLUSIVE)
+			.initial_layout(vk::ImageLayout::UNDEFINED);
+
+		let dst_image =
+			unsafe { device.create_image(&image_info, None) }.map_err(|e| format!("Downsampler image creation: {e}"))?;
+
+		let mem_req = unsafe { device.get_image_memory_requirements(dst_image) };
+		let memory_type_index = context
+			.find_memory_type(mem_req.memory_type_bits, vk::MemoryPropertyFlags::DEVICE_LOCAL)
+			.ok_or_else(|| {
+				unsafe { device.destroy_image(dst_image, None) };
+				"No device-local memory type for downsampler".to_string()
+			})?;
+
+		let alloc_info = vk::MemoryAllocateInfo::default()
+			.allocation_size(mem_req.size)
+			.memory_type_index(memory_type_index);
+		let dst_memory = unsafe { device.allocate_memory(&alloc_info, None) }.map_err(|e| {
+			unsafe { device.destroy_image(dst_image, None) };
+			format!("Downsampler memory allocation: {e}")
+		})?;
+
+		if let Err(e) = unsafe { device.bind_image_memory(dst_image, dst_memory, 0) } {
+			unsafe {
+				device.free_memory(dst_memory, None);
+				device.destroy_image(dst_image, None);
+			}
+			return Err(format!("Downsampler memory bind: {e}"));
+		}
+
+		// Create command pool on the transfer queue family.
+		let pool_info =
+			vk::CommandPoolCreateInfo::default().queue_family_index(context.compute_queue_family()).flags(
+				vk::CommandPoolCreateFlags::TRANSIENT | vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER,
+			);
+		let command_pool = unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
+			unsafe {
+				device.free_memory(dst_memory, None);
+				device.destroy_image(dst_image, None);
+			}
+			format!("Downsampler command pool: {e}")
+		})?;
+
+		let alloc_info = vk::CommandBufferAllocateInfo::default()
+			.command_pool(command_pool)
+			.level(vk::CommandBufferLevel::PRIMARY)
+			.command_buffer_count(1);
+		let command_buffer = unsafe { device.allocate_command_buffers(&alloc_info) }.map_err(|e| {
+			unsafe {
+				device.destroy_command_pool(command_pool, None);
+				device.free_memory(dst_memory, None);
+				device.destroy_image(dst_image, None);
+			}
+			format!("Downsampler command buffer: {e}")
+		})?[0];
+
+		let fence_info = vk::FenceCreateInfo::default();
+		let fence = unsafe { device.create_fence(&fence_info, None) }.map_err(|e| {
+			unsafe {
+				device.destroy_command_pool(command_pool, None);
+				device.free_memory(dst_memory, None);
+				device.destroy_image(dst_image, None);
+			}
+			format!("Downsampler fence: {e}")
+		})?;
+
+		Ok(Self {
+			context,
+			dst_image,
+			dst_memory,
+			command_pool,
+			command_buffer,
+			fence,
+			src_width,
+			src_height,
+			dst_width,
+			dst_height,
+			vk_format,
+		})
+	}
+
+	/// Blit `src_image` (at render resolution) down to the internal dst image (at encode resolution).
+	/// Returns the dst image in `GENERAL` layout.
+	pub fn blit(&mut self, src_image: vk::Image, src_layout: vk::ImageLayout) -> Result<vk::Image, String> {
+		let device = self.context.device();
+
+		let begin_info =
+			vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+		unsafe { device.begin_command_buffer(self.command_buffer, &begin_info) }
+			.map_err(|e| format!("Downsampler begin command buffer: {e}"))?;
+
+		let subresource = vk::ImageSubresourceRange::default()
+			.aspect_mask(vk::ImageAspectFlags::COLOR)
+			.base_mip_level(0)
+			.level_count(1)
+			.base_array_layer(0)
+			.layer_count(1);
+
+		// Transition src → TRANSFER_SRC_OPTIMAL.
+		let src_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(src_layout)
+			.new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(src_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE)
+			.dst_access_mask(vk::AccessFlags::TRANSFER_READ);
+
+		// Transition dst → TRANSFER_DST_OPTIMAL.
+		let dst_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::UNDEFINED)
+			.new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(self.dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::empty())
+			.dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::ALL_COMMANDS,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[src_barrier, dst_barrier],
+			);
+		}
+
+		let subresource_layers = vk::ImageSubresourceLayers::default()
+			.aspect_mask(vk::ImageAspectFlags::COLOR)
+			.mip_level(0)
+			.base_array_layer(0)
+			.layer_count(1);
+
+		let blit_region = vk::ImageBlit::default()
+			.src_subresource(subresource_layers)
+			.src_offsets([
+				vk::Offset3D { x: 0, y: 0, z: 0 },
+				vk::Offset3D { x: self.src_width as i32, y: self.src_height as i32, z: 1 },
+			])
+			.dst_subresource(subresource_layers)
+			.dst_offsets([
+				vk::Offset3D { x: 0, y: 0, z: 0 },
+				vk::Offset3D { x: self.dst_width as i32, y: self.dst_height as i32, z: 1 },
+			]);
+
+		unsafe {
+			device.cmd_blit_image(
+				self.command_buffer,
+				src_image,
+				vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+				self.dst_image,
+				vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+				&[blit_region],
+				vk::Filter::LINEAR,
+			);
+		}
+
+		// Transition src back → GENERAL.
+		let src_barrier_back = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+			.new_layout(vk::ImageLayout::GENERAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(src_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::TRANSFER_READ)
+			.dst_access_mask(vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE);
+
+		// Transition dst → GENERAL for downstream consumers.
+		let dst_barrier_back = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.new_layout(vk::ImageLayout::GENERAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(self.dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+			.dst_access_mask(vk::AccessFlags::MEMORY_READ | vk::AccessFlags::MEMORY_WRITE);
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::PipelineStageFlags::ALL_COMMANDS,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[src_barrier_back, dst_barrier_back],
+			);
+
+			device.end_command_buffer(self.command_buffer).map_err(|e| format!("Downsampler end command buffer: {e}"))?;
+		}
+
+		let submit_info =
+			vk::SubmitInfo::default().command_buffers(std::slice::from_ref(&self.command_buffer));
+		unsafe {
+			device
+				.queue_submit(self.context.compute_queue(), &[submit_info], self.fence)
+				.map_err(|e| format!("Downsampler queue submit: {e}"))?;
+			device
+				.wait_for_fences(&[self.fence], true, u64::MAX)
+				.map_err(|e| format!("Downsampler fence wait: {e}"))?;
+			device.reset_fences(&[self.fence]).map_err(|e| format!("Downsampler fence reset: {e}"))?;
+			device
+				.reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
+				.map_err(|e| format!("Downsampler command buffer reset: {e}"))?;
+		}
+
+		Ok(self.dst_image)
+	}
+
+	pub fn vk_format(&self) -> vk::Format {
+		self.vk_format
+	}
+}
+
+impl Drop for Downsampler {
+	fn drop(&mut self) {
+		let device = self.context.device();
+		unsafe {
+			device.destroy_fence(self.fence, None);
+			device.destroy_command_pool(self.command_pool, None);
+			device.free_memory(self.dst_memory, None);
+			device.destroy_image(self.dst_image, None);
+		}
+	}
+}

--- a/src/session/stream/video/pipeline/downsample.rs
+++ b/src/session/stream/video/pipeline/downsample.rs
@@ -44,7 +44,11 @@ impl Downsampler {
 		let image_info = vk::ImageCreateInfo::default()
 			.image_type(vk::ImageType::TYPE_2D)
 			.format(vk_format)
-			.extent(vk::Extent3D { width: dst_width, height: dst_height, depth: 1 })
+			.extent(vk::Extent3D {
+				width: dst_width,
+				height: dst_height,
+				depth: 1,
+			})
 			.mip_levels(1)
 			.array_layers(1)
 			.samples(vk::SampleCountFlags::TYPE_1)
@@ -53,8 +57,8 @@ impl Downsampler {
 			.sharing_mode(vk::SharingMode::EXCLUSIVE)
 			.initial_layout(vk::ImageLayout::UNDEFINED);
 
-		let dst_image =
-			unsafe { device.create_image(&image_info, None) }.map_err(|e| format!("Downsampler image creation: {e}"))?;
+		let dst_image = unsafe { device.create_image(&image_info, None) }
+			.map_err(|e| format!("Downsampler image creation: {e}"))?;
 
 		let mem_req = unsafe { device.get_image_memory_requirements(dst_image) };
 		let memory_type_index = context
@@ -81,10 +85,9 @@ impl Downsampler {
 		}
 
 		// Create command pool on the transfer queue family.
-		let pool_info =
-			vk::CommandPoolCreateInfo::default().queue_family_index(context.compute_queue_family()).flags(
-				vk::CommandPoolCreateFlags::TRANSIENT | vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER,
-			);
+		let pool_info = vk::CommandPoolCreateInfo::default()
+			.queue_family_index(context.compute_queue_family())
+			.flags(vk::CommandPoolCreateFlags::TRANSIENT | vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
 		let command_pool = unsafe { device.create_command_pool(&pool_info, None) }.map_err(|e| {
 			unsafe {
 				device.free_memory(dst_memory, None);
@@ -136,8 +139,7 @@ impl Downsampler {
 	pub fn blit(&mut self, src_image: vk::Image, src_layout: vk::ImageLayout) -> Result<vk::Image, String> {
 		let device = self.context.device();
 
-		let begin_info =
-			vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+		let begin_info = vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
 		unsafe { device.begin_command_buffer(self.command_buffer, &begin_info) }
 			.map_err(|e| format!("Downsampler begin command buffer: {e}"))?;
 
@@ -192,12 +194,20 @@ impl Downsampler {
 			.src_subresource(subresource_layers)
 			.src_offsets([
 				vk::Offset3D { x: 0, y: 0, z: 0 },
-				vk::Offset3D { x: self.src_width as i32, y: self.src_height as i32, z: 1 },
+				vk::Offset3D {
+					x: self.src_width as i32,
+					y: self.src_height as i32,
+					z: 1,
+				},
 			])
 			.dst_subresource(subresource_layers)
 			.dst_offsets([
 				vk::Offset3D { x: 0, y: 0, z: 0 },
-				vk::Offset3D { x: self.dst_width as i32, y: self.dst_height as i32, z: 1 },
+				vk::Offset3D {
+					x: self.dst_width as i32,
+					y: self.dst_height as i32,
+					z: 1,
+				},
 			]);
 
 		unsafe {
@@ -245,11 +255,12 @@ impl Downsampler {
 				&[src_barrier_back, dst_barrier_back],
 			);
 
-			device.end_command_buffer(self.command_buffer).map_err(|e| format!("Downsampler end command buffer: {e}"))?;
+			device
+				.end_command_buffer(self.command_buffer)
+				.map_err(|e| format!("Downsampler end command buffer: {e}"))?;
 		}
 
-		let submit_info =
-			vk::SubmitInfo::default().command_buffers(std::slice::from_ref(&self.command_buffer));
+		let submit_info = vk::SubmitInfo::default().command_buffers(std::slice::from_ref(&self.command_buffer));
 		unsafe {
 			device
 				.queue_submit(self.context.compute_queue(), &[submit_info], self.fence)
@@ -257,7 +268,9 @@ impl Downsampler {
 			device
 				.wait_for_fences(&[self.fence], true, u64::MAX)
 				.map_err(|e| format!("Downsampler fence wait: {e}"))?;
-			device.reset_fences(&[self.fence]).map_err(|e| format!("Downsampler fence reset: {e}"))?;
+			device
+				.reset_fences(&[self.fence])
+				.map_err(|e| format!("Downsampler fence reset: {e}"))?;
 			device
 				.reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty())
 				.map_err(|e| format!("Downsampler command buffer reset: {e}"))?;

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -4,7 +4,10 @@
 //! and packetization for network transmission.
 
 mod dmabuf;
+mod downsample;
 mod hdr_sei;
+
+use downsample::Downsampler;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -117,6 +120,8 @@ impl VideoPipeline {
 		frame_rx: std::sync::mpsc::Receiver<ExportedFrame>,
 		width: u32,
 		height: u32,
+		render_width: u32,
+		render_height: u32,
 		framerate: u32,
 		bitrate: usize,
 		packet_size: usize,
@@ -138,6 +143,8 @@ impl VideoPipeline {
 		let inner = VideoPipelineInner {
 			width,
 			height,
+			render_width,
+			render_height,
 			framerate,
 			bitrate,
 			packet_size,
@@ -171,6 +178,8 @@ impl VideoPipeline {
 struct VideoPipelineInner {
 	width: u32,
 	height: u32,
+	render_width: u32,
+	render_height: u32,
 	framerate: u32,
 	bitrate: usize,
 	packet_size: usize,
@@ -330,6 +339,9 @@ impl VideoPipelineInner {
 		// Color converter will be initialized on first frame.
 		let mut color_converter: Option<ColorConverter> = None;
 
+		// Downsampler for supersampling: initialized on first frame when render dims differ from encode dims.
+		let mut downsampler: Option<Downsampler> = None;
+
 		// Encoding loop - receives frames from compositor.
 		let frame_interval = std::time::Duration::from_secs_f64(1.0 / self.framerate as f64);
 		let mut last_frame_time = std::time::Instant::now();
@@ -481,6 +493,48 @@ impl VideoPipelineInner {
 				};
 
 				let t2_imported = std::time::Instant::now();
+
+				// Invalidate downsampler if the source format changed.
+				if let Some(ref d) = downsampler {
+					if d.vk_format() != import_vk_format {
+						downsampler = None;
+					}
+				}
+
+				// Downscale from compositor render resolution to encode resolution if supersampling active.
+				let (source_image, src_layout) = if self.render_width != self.width || self.render_height != self.height {
+					let ds = match &mut downsampler {
+						Some(d) => d,
+						None => match Downsampler::new(
+							context.clone(),
+							self.render_width,
+							self.render_height,
+							self.width,
+							self.height,
+							import_vk_format,
+						) {
+							Ok(d) => {
+								downsampler = Some(d);
+								downsampler.as_mut().unwrap()
+							},
+							Err(e) => {
+								tracing::warn!("Failed to create downsampler: {e}");
+								frame.consumed.store(true, Ordering::Release);
+								continue;
+							},
+						},
+					};
+					match ds.blit(source_image, src_layout) {
+						Ok(img) => (img, vk::ImageLayout::GENERAL),
+						Err(e) => {
+							tracing::warn!("Downscale blit failed: {e}");
+							frame.consumed.store(true, Ordering::Release);
+							continue;
+						},
+					}
+				} else {
+					(source_image, src_layout)
+				};
 
 				// Recreate the converter if the input format changed (e.g. GBM pool
 				// ABGR2101010 → direct scanout XBGR8888). The converter's image view

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -502,7 +502,8 @@ impl VideoPipelineInner {
 				}
 
 				// Downscale from compositor render resolution to encode resolution if supersampling active.
-				let (source_image, src_layout) = if self.render_width != self.width || self.render_height != self.height {
+				let (source_image, src_layout) = if self.render_width != self.width || self.render_height != self.height
+				{
 					let ds = match &mut downsampler {
 						Some(d) => d,
 						None => match Downsampler::new(


### PR DESCRIPTION
Renders the Wayland compositor at 2× the client-requested resolution for resolutions listed in `supersampled_resolutions`, then GPU-downscales to encode resolution before the color converter. Improves anti-aliasing on low-resolution clients at the cost of higher GPU load.

For example, running the Wayland compositor at 2560x1600 when being streamed to the Steam Deck at 1280×800. This improves anti-aliasing while keeping required streaming bandwidth low, and gives FSR/DLSS more resolution to work with instead of a client's low native resolution.

Configured in `config.toml` as e.g. `supersampled_resolutions = [[1280, 800], [1920, 1080]]`.

Tested with multiple resolutions against multiple titles running under the default XWayland and native Wayland via GE-Proton.