### PR TITLE
feat: pass convert semaphore through to encoder.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "pixelforge"
 version = "0.3.0"
-source = "git+https://github.com/hgaiser/pixelforge?rev=fc60c32#fc60c32dcc7684467bd0da3ab6f0cf56975a235d"
+source = "git+https://github.com/porkloin/pixelforge?rev=e1fb696#e1fb696f29af54d3bf0b4550402f9473b92f43fc"
 dependencies = [
  "ash",
  "shaderc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "pixelforge"
 version = "0.3.0"
-source = "git+https://github.com/porkloin/pixelforge?rev=e1fb696#e1fb696f29af54d3bf0b4550402f9473b92f43fc"
+source = "git+https://github.com/porkloin/pixelforge?rev=dc8e46f#dc8e46f31fc7ffa42c1e790231f2a13cdb8b8aba"
 dependencies = [
  "ash",
  "shaderc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ network-interface = "2.0.5"
 notify-rust = "4.12.0"
 open = "5.3.3"
 opus = "0.3.1"
-pixelforge = { git = "https://github.com/hgaiser/pixelforge", rev = "fc60c32", features = ["dmabuf"] }
+pixelforge = { git = "https://github.com/porkloin/pixelforge", rev = "e1fb696", features = ["dmabuf"] }
 pkcs8 = "0.10.2"
 pulseaudio = "0.3.1"
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ network-interface = "2.0.5"
 notify-rust = "4.12.0"
 open = "5.3.3"
 opus = "0.3.1"
-pixelforge = { git = "https://github.com/porkloin/pixelforge", rev = "e1fb696", features = ["dmabuf"] }
+pixelforge = { git = "https://github.com/porkloin/pixelforge", rev = "dc8e46f", features = ["dmabuf"] }
 pkcs8 = "0.10.2"
 pulseaudio = "0.3.1"
 rand = "0.8.5"

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -378,7 +378,7 @@ impl VideoPipelineInner {
 					// the last frame's data after color conversion).
 					if pending_idr && has_encoded {
 						tracing::debug!("Re-encoding last frame for IDR request (no re-import)");
-						let encode_result = encoder.encode(encoder.input_image());
+						let encode_result = encoder.encode(encoder.input_image(), None);
 						if let Ok(packets) = encode_result {
 							for packet in packets {
 								// Use current time as frame_created_at for re-encoded IDR (no actual frame)
@@ -554,12 +554,16 @@ impl VideoPipelineInner {
 					}
 				}
 
-				// Convert to YUV.
-				if let Err(e) = converter.convert(source_image, src_layout, encoder.input_image()) {
-					tracing::warn!("GPU color conversion failed: {e}");
-					frame.consumed.store(true, Ordering::Release);
-					continue;
-				}
+				// Convert to YUV. Returns a semaphore that the encoder waits on
+				// so convert and encode overlap on the GPU.
+				let convert_semaphore = match converter.convert(source_image, src_layout, encoder.input_image()) {
+					Ok(sem) => sem,
+					Err(e) => {
+						tracing::warn!("GPU color conversion failed: {e}");
+						frame.consumed.store(true, Ordering::Release);
+						continue;
+					},
+				};
 
 				// The DMA-BUF content has been read into the encoder's input
 				// image — signal the compositor that this GBM buffer is free.
@@ -591,8 +595,9 @@ impl VideoPipelineInner {
 
 				let t3_converted = std::time::Instant::now();
 
-				// Encode the converted image.
-				let encode_result = encoder.encode(encoder.input_image());
+				// Encode the converted image. The semaphore from convert ensures
+				// the GPU finishes conversion before encoding starts.
+				let encode_result = encoder.encode(encoder.input_image(), Some(convert_semaphore));
 
 				let t4_encoded = std::time::Instant::now();
 

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -5,6 +5,7 @@
 
 mod dmabuf;
 mod hdr_sei;
+mod rgb_blitter;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -210,7 +211,7 @@ impl VideoPipelineInner {
 		let _delay_stop = stop_session_manager.delay_shutdown_token();
 
 		// Create the encoder.
-		let (context, encoder) = match self.create_encoder() {
+		let (context, encoder, use_rgb_input) = match self.create_encoder() {
 			Ok(result) => result,
 			Err(e) => {
 				tracing::error!("Failed to create video encoder: {e}");
@@ -223,6 +224,7 @@ impl VideoPipelineInner {
 			frame_rx,
 			context,
 			encoder,
+			use_rgb_input,
 			packet_tx,
 			idr_frame_request_rx,
 			stop_session_manager,
@@ -234,7 +236,7 @@ impl VideoPipelineInner {
 		tracing::debug!("Video pipeline stopped.");
 	}
 
-	fn create_encoder(&self) -> Result<(VideoContext, Encoder), String> {
+	fn create_encoder(&self) -> Result<(VideoContext, Encoder, bool), String> {
 		// Create Vulkan video context.
 		let context = VideoContextBuilder::new()
 			.build()
@@ -246,6 +248,14 @@ impl VideoPipelineInner {
 			VideoFormat::Hevc => Codec::H265,
 			VideoFormat::Av1 => Codec::AV1,
 		};
+
+		// RGB-direct encode skips the compute-shader RGB→YUV pass and lets
+		// VCN5 do the conversion inline. Enabled for all codecs whenever
+		// the device advertises VK_VALVE_video_encode_rgb_conversion.
+		let use_rgb_input = context.supports_rgb_direct_encode();
+		if use_rgb_input {
+			tracing::info!("RGB-direct encode path active (VK_VALVE_video_encode_rgb_conversion)");
+		}
 
 		// Convert pixel format.
 		let pixel_format = match self.chroma_sampling {
@@ -281,11 +291,12 @@ impl VideoPipelineInner {
 		.with_b_frames(0) // No B-frames for low latency
 		.with_max_reference_frames(self.max_reference_frames)
 		.with_virtual_buffer_size_ms(1000 / self.framerate)
-		.with_initial_virtual_buffer_size_ms(0);
+		.with_initial_virtual_buffer_size_ms(0)
+		.with_rgb_input(use_rgb_input);
 
 		let encoder = Encoder::new(context.clone(), config).map_err(|e| format!("Failed to create encoder: {e}"))?;
 
-		Ok((context, encoder))
+		Ok((context, encoder, use_rgb_input))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -294,6 +305,7 @@ impl VideoPipelineInner {
 		frame_rx: std::sync::mpsc::Receiver<ExportedFrame>,
 		context: VideoContext,
 		mut encoder: Encoder,
+		use_rgb_input: bool,
 		packet_tx: mpsc::Sender<ShardBatch>,
 		mut idr_frame_request_rx: broadcast::Receiver<()>,
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
@@ -337,7 +349,9 @@ impl VideoPipelineInner {
 		};
 
 		// Color converter will be initialized on first frame.
+		// In RGB-direct mode this stays `None` and we use `rgb_blitter` instead.
 		let mut color_converter: Option<ColorConverter> = None;
+		let mut rgb_blitter: Option<rgb_blitter::RgbBlitter> = None;
 
 		// Encoding loop - receives frames from compositor.
 		let frame_interval = std::time::Duration::from_secs_f64(1.0 / self.framerate as f64);
@@ -491,87 +505,136 @@ impl VideoPipelineInner {
 
 				let t2_imported = std::time::Instant::now();
 
-				// Recreate the converter if the input format changed (e.g. GBM pool
-				// ABGR2101010 → direct scanout XBGR8888). The converter's image view
-				// format must match the source image format.
-				if let Some(ref conv) = color_converter {
-					if conv.config().input_format != frame_input_format {
-						tracing::info!(
-							"Input format changed from {:?} to {:?}, recreating color converter",
-							conv.config().input_format,
-							frame_input_format,
-						);
-						color_converter = None;
-					}
-				}
-
-				// Initialize converter if needed.
-				let converter = match &mut color_converter {
-					Some(conv) => conv,
-					None => {
-						let (color_space, full_range) = match self.dynamic_range {
-							VideoDynamicRange::Sdr => (ColorSpace::Bt709, true),
-							VideoDynamicRange::Hdr => (ColorSpace::Bt2020, false),
-						};
-						let mut config =
-							ColorConverterConfig::new(self.width, self.height, frame_input_format, output_format);
-						config.color_space = color_space;
-						config.full_range = full_range;
-						match ColorConverter::new(context.clone(), config) {
-							Ok(conv) => {
-								color_converter = Some(conv);
-								color_converter.as_mut().unwrap()
+				// `convert_semaphore` is `Some(sem)` in both paths — the
+				// converter (YUV) and blitter (RGB-direct) submit async
+				// and signal a semaphore the encoder waits on, so blit/
+				// convert and encode overlap on the GPU instead of
+				// serialising on a host fence wait.
+				let convert_semaphore: Option<vk::Semaphore> = if use_rgb_input {
+					// RGB-direct: skip the compute-shader converter and copy
+					// the imported DMA-BUF into the encoder's RGB input
+					// image. VCN5 will do the RGB→YUV conversion internally
+					// during encode. Color description / VUI is set at
+					// encoder-create time and (in HDR) switched per-frame
+					// via `set_color_description`.
+					let blitter = match &mut rgb_blitter {
+						Some(b) => b,
+						None => match rgb_blitter::RgbBlitter::new(context.clone(), self.width, self.height) {
+							Ok(b) => {
+								rgb_blitter = Some(b);
+								rgb_blitter.as_mut().unwrap()
 							},
 							Err(e) => {
-								tracing::warn!("Failed to create color converter: {e}");
+								tracing::warn!("Failed to create RGB blitter: {e}");
 								frame.consumed.store(true, Ordering::Release);
 								continue;
 							},
-						}
-					},
-				};
-
-				// In HDR mode, select per-frame color space and encoder VUI
-				// based on the frame's actual color space. SDR frames are
-				// encoded as BT.709 and HDR frames as BT.2020+PQ, with
-				// dynamic VUI switching in the encoder.
-				if self.dynamic_range == VideoDynamicRange::Hdr {
-					let frame_cs = frame.color_space;
-					let (cs, full_range, color_desc) = match frame_cs {
-						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709()),
-						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq()),
+						},
 					};
 
-					// Switch encoder VUI first. Only update the converter if
-					// the encoder switch succeeds, so that the converter's
-					// color space stays in sync with the encoder's VUI.
-					if encoder_color_desc != Some(color_desc) {
-						tracing::info!(
-							"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
-						);
-						match encoder.set_color_description(color_desc) {
-							Ok(()) => {
-								encoder_color_desc = Some(color_desc);
-								converter.set_color_space(cs);
-								converter.set_full_range(full_range);
-							},
-							Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+					if self.dynamic_range == VideoDynamicRange::Hdr {
+						let frame_cs = frame.color_space;
+						let color_desc = match frame_cs {
+							FrameColorSpace::Srgb => ColorDescription::bt709(),
+							FrameColorSpace::Bt2020Pq => ColorDescription::bt2020_pq(),
+						};
+						if encoder_color_desc != Some(color_desc) {
+							tracing::info!(
+								"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
+							);
+							match encoder.set_color_description(color_desc) {
+								Ok(()) => encoder_color_desc = Some(color_desc),
+								Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+							}
 						}
-					} else {
-						converter.set_color_space(cs);
-						converter.set_full_range(full_range);
 					}
-				}
 
-				// Convert to YUV. Returns a semaphore that the encoder waits on
-				// so convert and encode overlap on the GPU.
-				let convert_semaphore = match converter.convert(source_image, src_layout, encoder.input_image()) {
-					Ok(sem) => sem,
-					Err(e) => {
-						tracing::warn!("GPU color conversion failed: {e}");
-						frame.consumed.store(true, Ordering::Release);
-						continue;
-					},
+					match blitter.blit(source_image, src_layout, encoder.input_image()) {
+						Ok(sem) => Some(sem),
+						Err(e) => {
+							tracing::warn!("RGB blit failed: {e}");
+							frame.consumed.store(true, Ordering::Release);
+							continue;
+						},
+					}
+				} else {
+					// Recreate the converter if the input format changed (e.g. GBM pool
+					// ABGR2101010 → direct scanout XBGR8888). The converter's image view
+					// format must match the source image format.
+					if let Some(ref conv) = color_converter {
+						if conv.config().input_format != frame_input_format {
+							tracing::info!(
+								"Input format changed from {:?} to {:?}, recreating color converter",
+								conv.config().input_format,
+								frame_input_format,
+							);
+							color_converter = None;
+						}
+					}
+
+					// Initialize converter if needed.
+					let converter = match &mut color_converter {
+						Some(conv) => conv,
+						None => {
+							let (color_space, full_range) = match self.dynamic_range {
+								VideoDynamicRange::Sdr => (ColorSpace::Bt709, true),
+								VideoDynamicRange::Hdr => (ColorSpace::Bt2020, false),
+							};
+							let mut config =
+								ColorConverterConfig::new(self.width, self.height, frame_input_format, output_format);
+							config.color_space = color_space;
+							config.full_range = full_range;
+							match ColorConverter::new(context.clone(), config) {
+								Ok(conv) => {
+									color_converter = Some(conv);
+									color_converter.as_mut().unwrap()
+								},
+								Err(e) => {
+									tracing::warn!("Failed to create color converter: {e}");
+									frame.consumed.store(true, Ordering::Release);
+									continue;
+								},
+							}
+						},
+					};
+
+					// In HDR mode, select per-frame color space and encoder VUI
+					// based on the frame's actual color space.
+					if self.dynamic_range == VideoDynamicRange::Hdr {
+						let frame_cs = frame.color_space;
+						let (cs, full_range, color_desc) = match frame_cs {
+							FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709()),
+							FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq()),
+						};
+
+						if encoder_color_desc != Some(color_desc) {
+							tracing::info!(
+								"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
+							);
+							match encoder.set_color_description(color_desc) {
+								Ok(()) => {
+									encoder_color_desc = Some(color_desc);
+									converter.set_color_space(cs);
+									converter.set_full_range(full_range);
+								},
+								Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+							}
+						} else {
+							converter.set_color_space(cs);
+							converter.set_full_range(full_range);
+						}
+					}
+
+					// Convert to YUV. Returns a semaphore that the encoder waits on
+					// so convert and encode overlap on the GPU.
+					match converter.convert(source_image, src_layout, encoder.input_image()) {
+						Ok(sem) => Some(sem),
+						Err(e) => {
+							tracing::warn!("GPU color conversion failed: {e}");
+							frame.consumed.store(true, Ordering::Release);
+							continue;
+						},
+					}
 				};
 
 				// The DMA-BUF content has been read into the encoder's input
@@ -604,9 +667,11 @@ impl VideoPipelineInner {
 
 				let t3_converted = std::time::Instant::now();
 
-				// Encode the converted image. The semaphore from convert ensures
-				// the GPU finishes conversion before encoding starts.
-				let encode_result = encoder.encode(encoder.input_image(), Some(convert_semaphore));
+				// Encode the converted image. In the YUV path, the semaphore
+				// from convert ensures the GPU finishes conversion before
+				// encoding starts. In RGB-direct mode the blitter is
+				// synchronous, so no semaphore is needed.
+				let encode_result = encoder.encode(encoder.input_image(), convert_semaphore);
 
 				let t4_encoded = std::time::Instant::now();
 

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -387,7 +387,7 @@ impl VideoPipelineInner {
 					// the last frame's data after color conversion).
 					if pending_idr && has_encoded {
 						tracing::debug!("Re-encoding last frame for IDR request (no re-import)");
-						let encode_result = encoder.encode(encoder.input_image());
+						let encode_result = encoder.encode(encoder.input_image(), None);
 						if let Ok(packets) = encode_result {
 							for packet in packets {
 								// Use current time as frame_created_at for re-encoded IDR (no actual frame)
@@ -563,12 +563,16 @@ impl VideoPipelineInner {
 					}
 				}
 
-				// Convert to YUV.
-				if let Err(e) = converter.convert(source_image, src_layout, encoder.input_image()) {
-					tracing::warn!("GPU color conversion failed: {e}");
-					frame.consumed.store(true, Ordering::Release);
-					continue;
-				}
+				// Convert to YUV. Returns a semaphore that the encoder waits on
+				// so convert and encode overlap on the GPU.
+				let convert_semaphore = match converter.convert(source_image, src_layout, encoder.input_image()) {
+					Ok(sem) => sem,
+					Err(e) => {
+						tracing::warn!("GPU color conversion failed: {e}");
+						frame.consumed.store(true, Ordering::Release);
+						continue;
+					},
+				};
 
 				// The DMA-BUF content has been read into the encoder's input
 				// image — signal the compositor that this GBM buffer is free.
@@ -600,8 +604,9 @@ impl VideoPipelineInner {
 
 				let t3_converted = std::time::Instant::now();
 
-				// Encode the converted image.
-				let encode_result = encoder.encode(encoder.input_image());
+				// Encode the converted image. The semaphore from convert ensures
+				// the GPU finishes conversion before encoding starts.
+				let encode_result = encoder.encode(encoder.input_image(), Some(convert_semaphore));
 
 				let t4_encoded = std::time::Instant::now();
 

--- a/src/session/stream/video/pipeline/rgb_blitter.rs
+++ b/src/session/stream/video/pipeline/rgb_blitter.rs
@@ -1,0 +1,236 @@
+//! GPU-side RGB image copy used when the encoder is configured for
+//! `VK_VALVE_video_encode_rgb_conversion`.
+//!
+//! When RGB-direct encode is enabled, VCN5 does the RGB→YUV conversion
+//! itself, so the moonshine pipeline no longer needs the compute-shader
+//! `ColorConverter`. Instead we just have to land the imported DMA-BUF
+//! pixels into the encoder's input image. This module performs that copy
+//! with `vkCmdCopyImage` on the transfer queue, including the layout
+//! transitions that the encoder expects (`VIDEO_ENCODE_SRC_KHR` ↔
+//! `TRANSFER_DST_OPTIMAL`).
+//!
+//! Async semaphore-signaled, mirroring `pixelforge::ColorConverter`: a
+//! single fence + signal semaphore are reused across frames; on entry we
+//! wait on the previous frame's fence (so the semaphore is free to
+//! re-signal) and on exit we submit and return immediately, handing the
+//! semaphore back to the caller for the encoder to wait on. Lets blit
+//! and encode overlap on the GPU the same way convert/encode do.
+
+use ash::vk;
+use pixelforge::VideoContext;
+
+pub struct RgbBlitter {
+	context: VideoContext,
+	command_pool: vk::CommandPool,
+	command_buffer: vk::CommandBuffer,
+	fence: vk::Fence,
+	signal_semaphore: vk::Semaphore,
+	in_flight: bool,
+	width: u32,
+	height: u32,
+}
+
+impl RgbBlitter {
+	pub fn new(context: VideoContext, width: u32, height: u32) -> Result<Self, String> {
+		let device = context.device();
+		let queue_family = context.transfer_queue_family();
+
+		let pool_info = vk::CommandPoolCreateInfo::default()
+			.queue_family_index(queue_family)
+			.flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
+		let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
+			.map_err(|e| format!("RgbBlitter: create_command_pool: {e}"))?;
+
+		let alloc_info = vk::CommandBufferAllocateInfo::default()
+			.command_pool(command_pool)
+			.level(vk::CommandBufferLevel::PRIMARY)
+			.command_buffer_count(1);
+		let command_buffer = unsafe { device.allocate_command_buffers(&alloc_info) }
+			.map_err(|e| format!("RgbBlitter: allocate_command_buffers: {e}"))?[0];
+
+		let fence_info = vk::FenceCreateInfo::default();
+		let fence = unsafe { device.create_fence(&fence_info, None) }
+			.map_err(|e| format!("RgbBlitter: create_fence: {e}"))?;
+
+		let semaphore_info = vk::SemaphoreCreateInfo::default();
+		let signal_semaphore = unsafe { device.create_semaphore(&semaphore_info, None) }
+			.map_err(|e| format!("RgbBlitter: create_semaphore: {e}"))?;
+
+		Ok(Self {
+			context,
+			command_pool,
+			command_buffer,
+			fence,
+			signal_semaphore,
+			in_flight: false,
+			width,
+			height,
+		})
+	}
+
+	/// Submit a copy of `src_image` (in `src_layout`) into `dst_image` (the
+	/// encoder's input image, currently in `VIDEO_ENCODE_SRC_KHR`). Returns
+	/// a binary semaphore that signals when the copy is done — the caller
+	/// should pass it to the encoder's submit as a wait dependency, just
+	/// like `ColorConverter::convert()`.
+	///
+	/// Submission is async: the function returns once the command buffer is
+	/// queue-submitted, not when the GPU finishes. The semaphore is reused
+	/// across frames; the next call waits on the previous frame's fence
+	/// before resubmitting so the semaphore is free to re-signal.
+	pub fn blit(
+		&mut self,
+		src_image: vk::Image,
+		src_layout: vk::ImageLayout,
+		dst_image: vk::Image,
+	) -> Result<vk::Semaphore, String> {
+		let device = self.context.device();
+
+		// Wait for the previous frame's submission to complete before
+		// re-recording the command buffer and re-signaling the semaphore.
+		if self.in_flight {
+			unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) }
+				.map_err(|e| format!("RgbBlitter: wait_for_fences: {e}"))?;
+			self.in_flight = false;
+		}
+
+		unsafe { device.reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty()) }
+			.map_err(|e| format!("RgbBlitter: reset_command_buffer: {e}"))?;
+
+		let begin_info = vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+		unsafe { device.begin_command_buffer(self.command_buffer, &begin_info) }
+			.map_err(|e| format!("RgbBlitter: begin_command_buffer: {e}"))?;
+
+		let subresource = vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::COLOR,
+			base_mip_level: 0,
+			level_count: 1,
+			base_array_layer: 0,
+			layer_count: 1,
+		};
+
+		// Transition both images: src → TRANSFER_SRC, dst → TRANSFER_DST.
+		// We don't care about previous contents of either, so UNDEFINED is
+		// an acceptable old layout for the source on first import (the
+		// caller signals this via `src_layout = UNDEFINED`).
+		let src_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(src_layout)
+			.new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(src_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::empty())
+			.dst_access_mask(vk::AccessFlags::TRANSFER_READ);
+
+		let dst_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
+			.new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::empty())
+			.dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::TOP_OF_PIPE,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[src_barrier, dst_barrier],
+			);
+		}
+
+		let copy = vk::ImageCopy::default()
+			.src_subresource(vk::ImageSubresourceLayers {
+				aspect_mask: vk::ImageAspectFlags::COLOR,
+				mip_level: 0,
+				base_array_layer: 0,
+				layer_count: 1,
+			})
+			.src_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+			.dst_subresource(vk::ImageSubresourceLayers {
+				aspect_mask: vk::ImageAspectFlags::COLOR,
+				mip_level: 0,
+				base_array_layer: 0,
+				layer_count: 1,
+			})
+			.dst_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+			.extent(vk::Extent3D {
+				width: self.width,
+				height: self.height,
+				depth: 1,
+			});
+
+		unsafe {
+			device.cmd_copy_image(
+				self.command_buffer,
+				src_image,
+				vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+				dst_image,
+				vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+				&[copy],
+			);
+		}
+
+		// Transition dst back to VIDEO_ENCODE_SRC_KHR for the encoder.
+		let dst_back = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.new_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+			.dst_access_mask(vk::AccessFlags::empty());
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[dst_back],
+			);
+		}
+
+		unsafe { device.end_command_buffer(self.command_buffer) }
+			.map_err(|e| format!("RgbBlitter: end_command_buffer: {e}"))?;
+
+		// Submit with semaphore signal — do NOT wait for completion. The
+		// caller passes the returned semaphore to the encoder's submit as
+		// a wait dependency, so blit and encode overlap on the GPU.
+		unsafe { device.reset_fences(&[self.fence]) }
+			.map_err(|e| format!("RgbBlitter: reset_fences: {e}"))?;
+
+		let command_buffers = [self.command_buffer];
+		let signal_semaphores = [self.signal_semaphore];
+		let submit = vk::SubmitInfo::default()
+			.command_buffers(&command_buffers)
+			.signal_semaphores(&signal_semaphores);
+
+		unsafe { device.queue_submit(self.context.transfer_queue(), &[submit], self.fence) }
+			.map_err(|e| format!("RgbBlitter: queue_submit: {e}"))?;
+
+		self.in_flight = true;
+		Ok(self.signal_semaphore)
+	}
+}
+
+impl Drop for RgbBlitter {
+	fn drop(&mut self) {
+		let device = self.context.device();
+		unsafe {
+			let _ = device.device_wait_idle();
+			device.destroy_semaphore(self.signal_semaphore, None);
+			device.destroy_fence(self.fence, None);
+			device.destroy_command_pool(self.command_pool, None);
+		}
+	}
+}


### PR DESCRIPTION
This is a companion to [this pixelforge PR](https://github.com/hgaiser/pixelforge/pull/10). After that is merged, pixelforge's `Encoder::encode()` now takes an optional GPU wait semaphore so convert and encode can overlap on the GPU instead of CPU-blocking between them. this wires the semaphore returned by `converter.convert()` through to the encoder submit so the wait happens GPU-side. That PR has all the details on how and why this works, but tl;dr is it improves convert+encode by parallelizing some stuff