### PR TITLE
feat(encoder): RGB-direct encode via VK_VALVE_video_encode_rgb_conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,6 @@ dependencies = [
 [[package]]
 name = "pixelforge"
 version = "0.3.0"
-source = "git+https://github.com/hgaiser/pixelforge?rev=fc60c32#fc60c32dcc7684467bd0da3ab6f0cf56975a235d"
 dependencies = [
  "ash",
  "shaderc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ network-interface = "2.0.5"
 notify-rust = "4.12.0"
 open = "5.3.3"
 opus = "0.3.1"
-pixelforge = { git = "https://github.com/hgaiser/pixelforge", rev = "fc60c32", features = ["dmabuf"] }
+pixelforge = { git = "https://github.com/porkloin/pixelforge", branch = "vk-valve-video", features = ["dmabuf"] }
 pkcs8 = "0.10.2"
 pulseaudio = "0.3.1"
 rand = "0.8.5"

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,27 @@ pub struct VideoStreamConfig {
 	/// the messages can be very noisy.
 	#[serde(default = "default_false")]
 	pub log_frame_spikes: bool,
+
+	/// Controls use of `VK_VALVE_video_encode_rgb_conversion`, which lets the
+	/// video encoder do RGB→YUV conversion inline (skipping the compute-shader
+	/// convert path). Currently only RADV (AMD on Linux) advertises the
+	/// extension; other drivers fall through to the compute-shader path.
+	///
+	/// - `auto` (default): use it when the device advertises support.
+	/// - `off`: always use the compute-shader path, even when supported.
+	///   Useful as an escape hatch if a driver regresses or for A/B testing.
+	/// - `force`: require it; encoder creation fails loudly if not supported.
+	#[serde(default)]
+	pub rgb_direct_encode: RgbDirectMode,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RgbDirectMode {
+	#[default]
+	Auto,
+	Off,
+	Force,
 }
 
 impl Default for VideoStreamConfig {
@@ -260,6 +281,7 @@ impl Default for VideoStreamConfig {
 			fec_percentage: 20,
 			encrypt: false,
 			log_frame_spikes: false,
+			rgb_direct_encode: RgbDirectMode::default(),
 		}
 	}
 }

--- a/src/session/stream/video/mod.rs
+++ b/src/session/stream/video/mod.rs
@@ -253,6 +253,7 @@ impl VideoStreamInner {
 			stop_session_manager.clone(),
 			hdr_metadata_tx,
 			self.config.stream.video.log_frame_spikes,
+			self.config.stream.video.rgb_direct_encode,
 		)?;
 
 		self.pipeline = Some(pipeline);

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -14,6 +14,7 @@ use ash::vk;
 use async_shutdown::ShutdownManager;
 use tokio::sync::{broadcast, mpsc, watch};
 
+use crate::config::RgbDirectMode;
 use crate::session::compositor::frame::{ExportedFrame, FrameColorSpace, HdrModeState};
 use crate::session::manager::SessionShutdownReason;
 
@@ -142,6 +143,7 @@ impl VideoPipeline {
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
 		hdr_metadata_tx: watch::Sender<HdrModeState>,
 		log_frame_spikes: bool,
+		rgb_direct_mode: RgbDirectMode,
 	) -> Result<Self, ()> {
 		tracing::debug!("Initializing video pipeline.");
 
@@ -159,6 +161,7 @@ impl VideoPipeline {
 			max_reference_frames,
 			encryption_key,
 			log_frame_spikes,
+			rgb_direct_mode,
 		};
 
 		std::thread::Builder::new()
@@ -192,6 +195,8 @@ struct VideoPipelineInner {
 	max_reference_frames: u32,
 	encryption_key: Option<Vec<u8>>,
 	log_frame_spikes: bool,
+	/// Controls VK_VALVE_video_encode_rgb_conversion usage at encoder creation.
+	rgb_direct_mode: RgbDirectMode,
 }
 
 impl VideoPipelineInner {
@@ -251,10 +256,32 @@ impl VideoPipelineInner {
 
 		// RGB-direct encode skips the compute-shader RGB→YUV pass and lets
 		// the video encoder hardware do the conversion inline. Enabled
-		// whenever the device advertises VK_VALVE_video_encode_rgb_conversion.
-		let use_rgb_input = context.supports_rgb_direct_encode();
-		if use_rgb_input {
-			tracing::info!("RGB-direct encode path active (VK_VALVE_video_encode_rgb_conversion)");
+		// whenever the device advertises VK_VALVE_video_encode_rgb_conversion,
+		// unless overridden via [stream.video] rgb_direct_encode in config.
+		let device_supports_rgb_direct = context.supports_rgb_direct_encode();
+		let use_rgb_input = match self.rgb_direct_mode {
+			RgbDirectMode::Auto => device_supports_rgb_direct,
+			RgbDirectMode::Off => false,
+			RgbDirectMode::Force => {
+				if !device_supports_rgb_direct {
+					return Err(
+						"rgb_direct_encode = \"force\" but VK_VALVE_video_encode_rgb_conversion \
+						is not advertised by this device"
+							.to_string(),
+					);
+				}
+				true
+			},
+		};
+		match (self.rgb_direct_mode, device_supports_rgb_direct, use_rgb_input) {
+			(_, _, true) => tracing::info!("RGB-direct encode path active (VK_VALVE_video_encode_rgb_conversion)"),
+			(RgbDirectMode::Off, true, _) => tracing::info!(
+				"Compute-shader RGB→YUV path active (rgb_direct_encode = \"off\" overrides device support)"
+			),
+			(_, false, _) => tracing::info!(
+				"Compute-shader RGB→YUV path active (VK_VALVE_video_encode_rgb_conversion not supported by this device)"
+			),
+			_ => {},
 		}
 
 		// Convert pixel format.

--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -5,6 +5,7 @@
 
 mod dmabuf;
 mod hdr_sei;
+mod rgb_blitter;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -210,7 +211,7 @@ impl VideoPipelineInner {
 		let _delay_stop = stop_session_manager.delay_shutdown_token();
 
 		// Create the encoder.
-		let (context, encoder) = match self.create_encoder() {
+		let (context, encoder, use_rgb_input) = match self.create_encoder() {
 			Ok(result) => result,
 			Err(e) => {
 				tracing::error!("Failed to create video encoder: {e}");
@@ -223,6 +224,7 @@ impl VideoPipelineInner {
 			frame_rx,
 			context,
 			encoder,
+			use_rgb_input,
 			packet_tx,
 			idr_frame_request_rx,
 			stop_session_manager,
@@ -234,7 +236,7 @@ impl VideoPipelineInner {
 		tracing::debug!("Video pipeline stopped.");
 	}
 
-	fn create_encoder(&self) -> Result<(VideoContext, Encoder), String> {
+	fn create_encoder(&self) -> Result<(VideoContext, Encoder, bool), String> {
 		// Create Vulkan video context.
 		let context = VideoContextBuilder::new()
 			.build()
@@ -246,6 +248,14 @@ impl VideoPipelineInner {
 			VideoFormat::Hevc => Codec::H265,
 			VideoFormat::Av1 => Codec::AV1,
 		};
+
+		// RGB-direct encode skips the compute-shader RGB→YUV pass and lets
+		// the video encoder hardware do the conversion inline. Enabled
+		// whenever the device advertises VK_VALVE_video_encode_rgb_conversion.
+		let use_rgb_input = context.supports_rgb_direct_encode();
+		if use_rgb_input {
+			tracing::info!("RGB-direct encode path active (VK_VALVE_video_encode_rgb_conversion)");
+		}
 
 		// Convert pixel format.
 		let pixel_format = match self.chroma_sampling {
@@ -281,11 +291,12 @@ impl VideoPipelineInner {
 		.with_b_frames(0) // No B-frames for low latency
 		.with_max_reference_frames(self.max_reference_frames)
 		.with_virtual_buffer_size_ms(1000 / self.framerate)
-		.with_initial_virtual_buffer_size_ms(0);
+		.with_initial_virtual_buffer_size_ms(0)
+		.with_rgb_input(use_rgb_input);
 
 		let encoder = Encoder::new(context.clone(), config).map_err(|e| format!("Failed to create encoder: {e}"))?;
 
-		Ok((context, encoder))
+		Ok((context, encoder, use_rgb_input))
 	}
 
 	#[allow(clippy::too_many_arguments)]
@@ -294,6 +305,7 @@ impl VideoPipelineInner {
 		frame_rx: std::sync::mpsc::Receiver<ExportedFrame>,
 		context: VideoContext,
 		mut encoder: Encoder,
+		use_rgb_input: bool,
 		packet_tx: mpsc::Sender<ShardBatch>,
 		mut idr_frame_request_rx: broadcast::Receiver<()>,
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
@@ -337,7 +349,9 @@ impl VideoPipelineInner {
 		};
 
 		// Color converter will be initialized on first frame.
+		// In RGB-direct mode this stays `None` and we use `rgb_blitter` instead.
 		let mut color_converter: Option<ColorConverter> = None;
+		let mut rgb_blitter: Option<rgb_blitter::RgbBlitter> = None;
 
 		// Encoding loop - receives frames from compositor.
 		let frame_interval = std::time::Duration::from_secs_f64(1.0 / self.framerate as f64);
@@ -491,83 +505,133 @@ impl VideoPipelineInner {
 
 				let t2_imported = std::time::Instant::now();
 
-				// Recreate the converter if the input format changed (e.g. GBM pool
-				// ABGR2101010 → direct scanout XBGR8888). The converter's image view
-				// format must match the source image format.
-				if let Some(ref conv) = color_converter {
-					if conv.config().input_format != frame_input_format {
-						tracing::info!(
-							"Input format changed from {:?} to {:?}, recreating color converter",
-							conv.config().input_format,
-							frame_input_format,
-						);
-						color_converter = None;
-					}
-				}
-
-				// Initialize converter if needed.
-				let converter = match &mut color_converter {
-					Some(conv) => conv,
-					None => {
-						let (color_space, full_range) = match self.dynamic_range {
-							VideoDynamicRange::Sdr => (ColorSpace::Bt709, true),
-							VideoDynamicRange::Hdr => (ColorSpace::Bt2020, false),
-						};
-						let mut config =
-							ColorConverterConfig::new(self.width, self.height, frame_input_format, output_format);
-						config.color_space = color_space;
-						config.full_range = full_range;
-						match ColorConverter::new(context.clone(), config) {
-							Ok(conv) => {
-								color_converter = Some(conv);
-								color_converter.as_mut().unwrap()
+				if use_rgb_input {
+					// RGB-direct path: skip the compute-shader converter
+					// and copy the imported DMA-BUF straight into the
+					// encoder's RGB-formatted input image. The encoder
+					// hardware does the RGB→YUV conversion inline.
+					let blitter = match &mut rgb_blitter {
+						Some(b) => b,
+						None => match rgb_blitter::RgbBlitter::new(context.clone(), self.width, self.height) {
+							Ok(b) => {
+								rgb_blitter = Some(b);
+								rgb_blitter.as_mut().unwrap()
 							},
 							Err(e) => {
-								tracing::warn!("Failed to create color converter: {e}");
+								tracing::warn!("Failed to create RGB blitter: {e}");
 								frame.consumed.store(true, Ordering::Release);
 								continue;
 							},
-						}
-					},
-				};
-
-				// In HDR mode, select per-frame color space and encoder VUI
-				// based on the frame's actual color space. SDR frames are
-				// encoded as BT.709 and HDR frames as BT.2020+PQ, with
-				// dynamic VUI switching in the encoder.
-				if self.dynamic_range == VideoDynamicRange::Hdr {
-					let frame_cs = frame.color_space;
-					let (cs, full_range, color_desc) = match frame_cs {
-						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709()),
-						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq()),
+						},
 					};
 
-					// Switch encoder VUI first. Only update the converter if
-					// the encoder switch succeeds, so that the converter's
-					// color space stays in sync with the encoder's VUI.
-					if encoder_color_desc != Some(color_desc) {
-						tracing::info!(
-							"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
-						);
-						match encoder.set_color_description(color_desc) {
-							Ok(()) => {
-								encoder_color_desc = Some(color_desc);
-								converter.set_color_space(cs);
-								converter.set_full_range(full_range);
-							},
-							Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+					// In HDR mode, switch encoder VUI per-frame based on
+					// the frame's actual color space. With RGB-direct there
+					// is no software converter to keep in sync; the encoder
+					// handles the color matrix internally.
+					if self.dynamic_range == VideoDynamicRange::Hdr {
+						let frame_cs = frame.color_space;
+						let color_desc = match frame_cs {
+							FrameColorSpace::Srgb => ColorDescription::bt709(),
+							FrameColorSpace::Bt2020Pq => ColorDescription::bt2020_pq(),
+						};
+						if encoder_color_desc != Some(color_desc) {
+							tracing::info!(
+								"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
+							);
+							match encoder.set_color_description(color_desc) {
+								Ok(()) => encoder_color_desc = Some(color_desc),
+								Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+							}
 						}
-					} else {
-						converter.set_color_space(cs);
-						converter.set_full_range(full_range);
 					}
-				}
 
-				// Convert to YUV.
-				if let Err(e) = converter.convert(source_image, src_layout, encoder.input_image()) {
-					tracing::warn!("GPU color conversion failed: {e}");
-					frame.consumed.store(true, Ordering::Release);
-					continue;
+					if let Err(e) = blitter.copy(source_image, src_layout, encoder.input_image()) {
+						tracing::warn!("RGB blit failed: {e}");
+						frame.consumed.store(true, Ordering::Release);
+						continue;
+					}
+				} else {
+					// Compute-shader path: convert RGB → YUV before encoding.
+					// Recreate the converter if the input format changed (e.g.
+					// GBM pool ABGR2101010 → direct scanout XBGR8888). The
+					// converter's image view format must match the source
+					// image format.
+					if let Some(ref conv) = color_converter {
+						if conv.config().input_format != frame_input_format {
+							tracing::info!(
+								"Input format changed from {:?} to {:?}, recreating color converter",
+								conv.config().input_format,
+								frame_input_format,
+							);
+							color_converter = None;
+						}
+					}
+
+					// Initialize converter if needed.
+					let converter = match &mut color_converter {
+						Some(conv) => conv,
+						None => {
+							let (color_space, full_range) = match self.dynamic_range {
+								VideoDynamicRange::Sdr => (ColorSpace::Bt709, true),
+								VideoDynamicRange::Hdr => (ColorSpace::Bt2020, false),
+							};
+							let mut config =
+								ColorConverterConfig::new(self.width, self.height, frame_input_format, output_format);
+							config.color_space = color_space;
+							config.full_range = full_range;
+							match ColorConverter::new(context.clone(), config) {
+								Ok(conv) => {
+									color_converter = Some(conv);
+									color_converter.as_mut().unwrap()
+								},
+								Err(e) => {
+									tracing::warn!("Failed to create color converter: {e}");
+									frame.consumed.store(true, Ordering::Release);
+									continue;
+								},
+							}
+						},
+					};
+
+					// In HDR mode, select per-frame color space and encoder VUI
+					// based on the frame's actual color space. SDR frames are
+					// encoded as BT.709 and HDR frames as BT.2020+PQ, with
+					// dynamic VUI switching in the encoder.
+					if self.dynamic_range == VideoDynamicRange::Hdr {
+						let frame_cs = frame.color_space;
+						let (cs, full_range, color_desc) = match frame_cs {
+							FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709()),
+							FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq()),
+						};
+
+						// Switch encoder VUI first. Only update the converter if
+						// the encoder switch succeeds, so that the converter's
+						// color space stays in sync with the encoder's VUI.
+						if encoder_color_desc != Some(color_desc) {
+							tracing::info!(
+								"Switching encoder color description to {color_desc:?} (frame_cs: {frame_cs:?})"
+							);
+							match encoder.set_color_description(color_desc) {
+								Ok(()) => {
+									encoder_color_desc = Some(color_desc);
+									converter.set_color_space(cs);
+									converter.set_full_range(full_range);
+								},
+								Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
+							}
+						} else {
+							converter.set_color_space(cs);
+							converter.set_full_range(full_range);
+						}
+					}
+
+					// Convert to YUV.
+					if let Err(e) = converter.convert(source_image, src_layout, encoder.input_image()) {
+						tracing::warn!("GPU color conversion failed: {e}");
+						frame.consumed.store(true, Ordering::Release);
+						continue;
+					}
 				}
 
 				// The DMA-BUF content has been read into the encoder's input

--- a/src/session/stream/video/pipeline/rgb_blitter.rs
+++ b/src/session/stream/video/pipeline/rgb_blitter.rs
@@ -1,0 +1,205 @@
+//! GPU-side RGB image copy used when the encoder is configured for
+//! `VK_VALVE_video_encode_rgb_conversion`.
+//!
+//! When RGB-direct encode is enabled, the video encoder hardware does
+//! the RGB→YUV conversion itself, so the moonshine pipeline no longer
+//! needs the compute-shader `ColorConverter`. Instead we just have to
+//! land the imported DMA-BUF pixels into the encoder's input image.
+//! This module performs that copy with `vkCmdCopyImage` on the transfer
+//! queue, including the layout transitions that the encoder expects
+//! (`VIDEO_ENCODE_SRC_KHR` ↔ `TRANSFER_DST_OPTIMAL`).
+//!
+//! Submits and synchronously waits on a fence before returning. The
+//! caller is responsible for any further synchronization between the
+//! blit and downstream encode work.
+
+use ash::vk;
+use pixelforge::VideoContext;
+
+pub struct RgbBlitter {
+	context: VideoContext,
+	command_pool: vk::CommandPool,
+	command_buffer: vk::CommandBuffer,
+	fence: vk::Fence,
+	width: u32,
+	height: u32,
+}
+
+impl RgbBlitter {
+	pub fn new(context: VideoContext, width: u32, height: u32) -> Result<Self, String> {
+		let device = context.device();
+		let queue_family = context.transfer_queue_family();
+
+		let pool_info = vk::CommandPoolCreateInfo::default()
+			.queue_family_index(queue_family)
+			.flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
+		let command_pool = unsafe { device.create_command_pool(&pool_info, None) }
+			.map_err(|e| format!("RgbBlitter: create_command_pool: {e}"))?;
+
+		let alloc_info = vk::CommandBufferAllocateInfo::default()
+			.command_pool(command_pool)
+			.level(vk::CommandBufferLevel::PRIMARY)
+			.command_buffer_count(1);
+		let command_buffer = unsafe { device.allocate_command_buffers(&alloc_info) }
+			.map_err(|e| format!("RgbBlitter: allocate_command_buffers: {e}"))?[0];
+
+		let fence_info = vk::FenceCreateInfo::default();
+		let fence =
+			unsafe { device.create_fence(&fence_info, None) }.map_err(|e| format!("RgbBlitter: create_fence: {e}"))?;
+
+		Ok(Self {
+			context,
+			command_pool,
+			command_buffer,
+			fence,
+			width,
+			height,
+		})
+	}
+
+	/// Copy `src_image` (in `src_layout`) into `dst_image` (the encoder's
+	/// input image, currently in `VIDEO_ENCODE_SRC_KHR`). Returns once the
+	/// GPU has finished, leaving `dst_image` ready for the encoder.
+	pub fn copy(
+		&mut self,
+		src_image: vk::Image,
+		src_layout: vk::ImageLayout,
+		dst_image: vk::Image,
+	) -> Result<(), String> {
+		let device = self.context.device();
+
+		unsafe { device.reset_command_buffer(self.command_buffer, vk::CommandBufferResetFlags::empty()) }
+			.map_err(|e| format!("RgbBlitter: reset_command_buffer: {e}"))?;
+
+		let begin_info = vk::CommandBufferBeginInfo::default().flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+		unsafe { device.begin_command_buffer(self.command_buffer, &begin_info) }
+			.map_err(|e| format!("RgbBlitter: begin_command_buffer: {e}"))?;
+
+		let subresource = vk::ImageSubresourceRange {
+			aspect_mask: vk::ImageAspectFlags::COLOR,
+			base_mip_level: 0,
+			level_count: 1,
+			base_array_layer: 0,
+			layer_count: 1,
+		};
+
+		// Transition both images: src → TRANSFER_SRC, dst → TRANSFER_DST.
+		// We don't care about previous contents of either; UNDEFINED is an
+		// acceptable old layout for the source on first import (caller
+		// signals this via `src_layout = UNDEFINED`).
+		let src_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(src_layout)
+			.new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(src_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::empty())
+			.dst_access_mask(vk::AccessFlags::TRANSFER_READ);
+
+		let dst_barrier = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
+			.new_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::empty())
+			.dst_access_mask(vk::AccessFlags::TRANSFER_WRITE);
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::TOP_OF_PIPE,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[src_barrier, dst_barrier],
+			);
+		}
+
+		let copy = vk::ImageCopy::default()
+			.src_subresource(vk::ImageSubresourceLayers {
+				aspect_mask: vk::ImageAspectFlags::COLOR,
+				mip_level: 0,
+				base_array_layer: 0,
+				layer_count: 1,
+			})
+			.src_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+			.dst_subresource(vk::ImageSubresourceLayers {
+				aspect_mask: vk::ImageAspectFlags::COLOR,
+				mip_level: 0,
+				base_array_layer: 0,
+				layer_count: 1,
+			})
+			.dst_offset(vk::Offset3D { x: 0, y: 0, z: 0 })
+			.extent(vk::Extent3D {
+				width: self.width,
+				height: self.height,
+				depth: 1,
+			});
+
+		unsafe {
+			device.cmd_copy_image(
+				self.command_buffer,
+				src_image,
+				vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+				dst_image,
+				vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+				&[copy],
+			);
+		}
+
+		// Transition dst back to VIDEO_ENCODE_SRC_KHR for the encoder.
+		let dst_back = vk::ImageMemoryBarrier::default()
+			.old_layout(vk::ImageLayout::TRANSFER_DST_OPTIMAL)
+			.new_layout(vk::ImageLayout::VIDEO_ENCODE_SRC_KHR)
+			.src_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.dst_queue_family_index(vk::QUEUE_FAMILY_IGNORED)
+			.image(dst_image)
+			.subresource_range(subresource)
+			.src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
+			.dst_access_mask(vk::AccessFlags::empty());
+
+		unsafe {
+			device.cmd_pipeline_barrier(
+				self.command_buffer,
+				vk::PipelineStageFlags::TRANSFER,
+				vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+				vk::DependencyFlags::empty(),
+				&[],
+				&[],
+				&[dst_back],
+			);
+		}
+
+		unsafe { device.end_command_buffer(self.command_buffer) }
+			.map_err(|e| format!("RgbBlitter: end_command_buffer: {e}"))?;
+
+		// Submit and wait synchronously on the fence.
+		unsafe { device.reset_fences(&[self.fence]) }.map_err(|e| format!("RgbBlitter: reset_fences: {e}"))?;
+
+		let command_buffers = [self.command_buffer];
+		let submit = vk::SubmitInfo::default().command_buffers(&command_buffers);
+
+		unsafe { device.queue_submit(self.context.transfer_queue(), &[submit], self.fence) }
+			.map_err(|e| format!("RgbBlitter: queue_submit: {e}"))?;
+
+		unsafe { device.wait_for_fences(&[self.fence], true, u64::MAX) }
+			.map_err(|e| format!("RgbBlitter: wait_for_fences: {e}"))?;
+
+		Ok(())
+	}
+}
+
+impl Drop for RgbBlitter {
+	fn drop(&mut self) {
+		let device = self.context.device();
+		unsafe {
+			let _ = device.device_wait_idle();
+			device.destroy_fence(self.fence, None);
+			device.destroy_command_pool(self.command_pool, None);
+		}
+	}
+}


### PR DESCRIPTION
Wires the direct RGB encoding path from https://github.com/hgaiser/pixelforge/pull/14. If a device advertises that it supports  VK_VALVE_video_encode_rgb_conversion, pipeline will use `RgbBlitter`instead of the `ColorConverter` to do direct RGB output into the encoder.

Also adds a config val for safety (`rgb_direct_encode` under `[stream.video]`, with either `auto`, `off`, or `force` as allowed values. Just in case future driver regressions occur or something, that way users can turn the feature off as a self-support mechanism. 

This only supports AMD cards for now, but hopefully other vendors will be supported in the future. There is also a log message to indicate whether or not direct RGB is being used, for quick diagnostic if it does cause problems on other vendor cards.


Depends on pixelforge PR 14 being in before this can be merged.