### PR TITLE
fix(video/pipeline): handle XBGR16161616F fourcc

### DIFF
--- a/src/session/stream/video/pipeline/mod.rs
+++ b/src/session/stream/video/pipeline/mod.rs
@@ -35,7 +35,7 @@ fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
 	// ABGR8888 = 0x34324241, XBGR8888 = 0x34324258
 	// ABGR2101010 = 0x30334241, XBGR2101010 = 0x30334258
 	// ARGB2101010 = 0x30335241, XRGB2101010 = 0x30335258
-	// ABGR16161616F = 0x48344241
+	// ABGR16161616F = 0x48344241, XBGR16161616F = 0x48344258
 	//
 	// X-variants share the same bit layout as their A-counterparts; the
 	// alpha bits are simply ignored. vkd3d-proton's swapchain typically
@@ -47,8 +47,8 @@ fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
 		0x30334241 | 0x30334258 => {
 			(InputFormat::ABGR2101010, vk::Format::A2B10G10R10_UNORM_PACK32) // ABGR/XBGR 2101010
 		},
-		0x48344241 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT), // ABGR16161616F
-		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM),                  // ARGB/XRGB8888 (fallback)
+		0x48344241 | 0x48344258 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT), // ABGR/XBGR16161616F
+		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM),                               // ARGB/XRGB8888 (fallback)
 	}
 }
 


### PR DESCRIPTION
Was testing Moonshine's HDR capabilities with Kingdom Come: Deliverance II and Witcher 3  on NVIDIA 5060 Ti, the stream was clipping and generally looking wrong - the client was receiving HDR frames fine, just decoding them as garbage.

Looked at the frame imports and every frame had `fourcc=XB4H` (`XBGR16161616F`). In `drm_fourcc_to_input`, only the A-variant (`0x48344241`) is matched, so the X-variant falls through to the 8-bit BGRx fallback.

The fix pairs the X and A variants, matching what the file already does for the 8-bit and 10-bit formats right above. The FP16 entry was the only one not paired. 

Also added tests for all three pairs plus the unknown-fourcc fallback. The FP16 case is the regression guard for this specific bug.

On its own this doesn't get scRGB HDR fully working - the frames stop being mangled, but the encoder still treats the decoded scRGB-linear pixels as SDR BT.709 because `EXTENDED_SRGB_LINEAR_EXT` swapchain feedback isn't handled in `gamescope_swapchain.rs`. Will send follow-up PRs for the scRGB→BT.2020+PQ path and a related compositor render-format change (managed to get KCD2, Witcher3 HDR working correctly on my setup)

Just in case, my setup:
- Headless Arch VM through Proxmox
- RTX 5060 Ti 16GB
- Stream to Mac with HDR 4:4:4 enabled in Moonlight (for testing ofc)

## References

- **Linux kernel `drm_fourcc.h`** ([`include/uapi/drm/drm_fourcc.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/drm/drm_fourcc.h)) - `DRM_FORMAT_XBGR16161616F = fourcc_code('X','B','4','H')` = `0x48344258`, and `DRM_FORMAT_ABGR16161616F = 'A','B','4','H'` = `0x48344241`. Same `[63:0] x:B:G:R` / `A:B:G:R` 16:16:16:16 little-endian layout, only the leading 16 bits differ in meaning (padding vs. alpha).
- Existing code in the same file, lines 46-48, uses the same `ABGR | XBGR` grouping for 8-bit and 10-bit already - this patch just completes the pattern for FP16.

NOTE: fix and investigation were done with support of Opus 4.7, in case that matters. Just dipping my toes into rendering and Rust, open for changes/adjustments. Thanks for awesome project!