### PR TITLE
Dockerfile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag moonshine:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM archlinux:base
 
 # 1. Configure pacman
-RUN sed -i '/^#\[multilib\]/s/^#//' /etc/pacman.conf && \
-    sed -i '/^#Include = \/etc\/pacman.d\/mirrorlist/s/^#//' /etc/pacman.conf && \
+RUN echo -e "\n[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf && \
     sed -i 's/^#ParallelDownloads/ParallelDownloads/' /etc/pacman.conf
 
 # 2. Update and install base dependencies, GPU drivers, and audio
@@ -13,7 +12,7 @@ RUN pacman -Syu --noconfirm \
     nvidia-utils lib32-nvidia-utils \
     pipewire pipewire-pulse pipewire-alsa pipewire-jack \
     ttf-liberation ttf-dejavu noto-fonts noto-fonts-cjk \
-    sudo curl wget dbus xorg-xwayland gosu
+    sudo curl wget dbus xorg-xwayland
 
 # 3. Install Steam
 RUN pacman -S --noconfirm steam && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM archlinux:base
+
+# 1. Configure pacman
+RUN sed -i '/^#\[multilib\]/s/^#//' /etc/pacman.conf && \
+    sed -i '/^#Include = \/etc\/pacman.d\/mirrorlist/s/^#//' /etc/pacman.conf && \
+    sed -i 's/^#ParallelDownloads/ParallelDownloads/' /etc/pacman.conf
+
+# 2. Update and install base dependencies, GPU drivers, and audio
+RUN pacman -Syu --noconfirm \
+    mesa lib32-mesa \
+    vulkan-radeon lib32-vulkan-radeon \
+    vulkan-intel lib32-vulkan-intel intel-media-driver \
+    nvidia-utils lib32-nvidia-utils \
+    pipewire pipewire-pulse pipewire-alsa pipewire-jack \
+    ttf-liberation ttf-dejavu noto-fonts noto-fonts-cjk \
+    sudo curl wget dbus xorg-xwayland gosu
+
+# 3. Install Steam
+RUN pacman -S --noconfirm steam && \
+    pacman -Scc --noconfirm
+
+# 4. Install Lutris, Wine and dependencies
+RUN pacman -S --noconfirm \
+    lutris wine-staging winetricks \
+    gamemode lib32-gamemode mangohud lib32-mangohud \
+    giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls \
+    mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse \
+    libgpg-error lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib \
+    libjpeg-turbo lib32-libjpeg-turbo sqlite lib32-sqlite libxcomposite lib32-libxcomposite \
+    libxinerama lib32-libxinerama ncurses lib32-ncurses opencl-icd-loader lib32-opencl-icd-loader \
+    libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs \
+    lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader && \
+    pacman -Scc --noconfirm
+
+# 5. Create unprivileged user (needed for AUR builds)
+RUN useradd -m -s /bin/bash -u 1000 moonshine && \
+    usermod -aG video,audio,render,input moonshine && \
+    echo "moonshine ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+# 6. Install ES-DE & Moonshine via AUR
+RUN pacman -S --noconfirm git base-devel && \
+    sudo -u moonshine bash -c "git clone https://aur.archlinux.org/yay-bin.git /tmp/yay-bin && cd /tmp/yay-bin && makepkg -si --noconfirm" && \
+    sudo -u moonshine bash -c "yay -S --noconfirm emulationstation-de moonshine" && \
+    rm -rf /tmp/yay-bin /home/moonshine/.cache/yay && \
+    pacman -Scc --noconfirm
+
+# 7. Set up entrypoint
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# NVIDIA runtime variables
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["moonshine"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,13 @@ RUN pacman -S --noconfirm git base-devel && \
     rm -rf /tmp/yay-bin /home/moonshine/.cache/yay && \
     pacman -Scc --noconfirm
 
-# 6. Enable systemd services and user lingering.
-# - dbus / avahi: required for zeroconf discovery
-# - moonshine@moonshine: the streaming server (from the AUR package)
-# - linger: starts systemd --user at boot without requiring a login session,
-#   which is required because moonshine uses "systemd-run --user --scope"
-#   to launch applications.
-RUN systemctl enable dbus avahi-daemon moonshine@moonshine && \
-    mkdir -p /var/lib/systemd/linger && touch /var/lib/systemd/linger/moonshine
+# 6. Install systemd-run shim.
+# Moonshine uses "systemd-run --user --scope" to launch applications,
+# which requires a full systemd user instance. In a container we replace
+# it with a shim that strips the systemd-run flags and execs the command
+# directly. Placed in /usr/local/bin so it shadows /usr/bin/systemd-run.
+COPY systemd-run-shim.sh /usr/local/bin/systemd-run
+RUN chmod +x /usr/local/bin/systemd-run
 
 # 7. Set up entrypoint
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -54,3 +53,4 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["moonshine", "/home/moonshine/.config/moonshine/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pacman -Syu --noconfirm \
     nvidia-utils lib32-nvidia-utils \
     pipewire pipewire-pulse pipewire-alsa pipewire-jack \
     ttf-liberation ttf-dejavu noto-fonts noto-fonts-cjk \
-    sudo curl wget xorg-xwayland
+    sudo curl wget xorg-xwayland avahi
 
 # 3. Install Steam, Lutris, Wine and dependencies
 RUN pacman -S --noconfirm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,16 @@ RUN pacman -S --noconfirm git base-devel && \
     rm -rf /tmp/yay-bin /home/moonshine/.cache/yay && \
     pacman -Scc --noconfirm
 
-# 6. Set up entrypoint
+# 6. Enable systemd services and user lingering.
+# - dbus / avahi: required for zeroconf discovery
+# - moonshine@moonshine: the streaming server (from the AUR package)
+# - linger: starts systemd --user at boot without requiring a login session,
+#   which is required because moonshine uses "systemd-run --user --scope"
+#   to launch applications.
+RUN systemctl enable dbus avahi-daemon moonshine@moonshine && \
+    mkdir -p /var/lib/systemd/linger && touch /var/lib/systemd/linger/moonshine
+
+# 7. Set up entrypoint
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
@@ -45,4 +54,3 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["moonshine", "/home/moonshine/.config/moonshine/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,9 @@ RUN pacman -Syu --noconfirm \
     ttf-liberation ttf-dejavu noto-fonts noto-fonts-cjk \
     sudo curl wget xorg-xwayland
 
-# 3. Install Steam
-RUN pacman -S --noconfirm steam && \
-    pacman -Scc --noconfirm
-
-# 4. Install Lutris, Wine and dependencies
+# 3. Install Steam, Lutris, Wine and dependencies
 RUN pacman -S --noconfirm \
-    lutris wine-staging winetricks \
+    steam lutris wine-staging winetricks \
     gamemode lib32-gamemode mangohud lib32-mangohud \
     lib32-giflib lib32-mpg123 openal lib32-openal \
     v4l-utils lib32-v4l-utils lib32-libpulse lib32-libjpeg-turbo \
@@ -28,19 +24,19 @@ RUN pacman -S --noconfirm \
     libxslt lib32-libxslt lib32-gtk3 && \
     pacman -Scc --noconfirm
 
-# 5. Create unprivileged user (needed for AUR builds)
+# 4. Create unprivileged user (needed for AUR builds)
 RUN useradd -m -s /bin/bash -u 1000 moonshine && \
     usermod -aG video,audio,render,input moonshine && \
     echo "moonshine ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-# 6. Install ES-DE & Moonshine via AUR
+# 5. Install ES-DE & Moonshine via AUR
 RUN pacman -S --noconfirm git base-devel && \
     sudo -u moonshine bash -c "git clone https://aur.archlinux.org/yay-bin.git /tmp/yay-bin && cd /tmp/yay-bin && makepkg -si --noconfirm" && \
     sudo -u moonshine bash -c "yay -S --noconfirm emulationstation-de moonshine" && \
     rm -rf /tmp/yay-bin /home/moonshine/.cache/yay && \
     pacman -Scc --noconfirm
 
-# 7. Set up entrypoint
+# 6. Set up entrypoint
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
@@ -49,4 +45,4 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["moonshine"]
+CMD ["moonshine", "/home/moonshine/.config/moonshine/config.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pacman -Syu --noconfirm \
     nvidia-utils lib32-nvidia-utils \
     pipewire pipewire-pulse pipewire-alsa pipewire-jack \
     ttf-liberation ttf-dejavu noto-fonts noto-fonts-cjk \
-    sudo curl wget dbus xorg-xwayland
+    sudo curl wget xorg-xwayland
 
 # 3. Install Steam
 RUN pacman -S --noconfirm steam && \
@@ -22,13 +22,10 @@ RUN pacman -S --noconfirm steam && \
 RUN pacman -S --noconfirm \
     lutris wine-staging winetricks \
     gamemode lib32-gamemode mangohud lib32-mangohud \
-    giflib lib32-giflib libpng lib32-libpng libldap lib32-libldap gnutls lib32-gnutls \
-    mpg123 lib32-mpg123 openal lib32-openal v4l-utils lib32-v4l-utils libpulse lib32-libpulse \
-    libgpg-error lib32-libgpg-error alsa-plugins lib32-alsa-plugins alsa-lib lib32-alsa-lib \
-    libjpeg-turbo lib32-libjpeg-turbo sqlite lib32-sqlite libxcomposite lib32-libxcomposite \
-    libxinerama lib32-libxinerama ncurses lib32-ncurses opencl-icd-loader lib32-opencl-icd-loader \
-    libxslt lib32-libxslt libva lib32-libva gtk3 lib32-gtk3 gst-plugins-base-libs \
-    lib32-gst-plugins-base-libs vulkan-icd-loader lib32-vulkan-icd-loader && \
+    lib32-giflib lib32-mpg123 openal lib32-openal \
+    v4l-utils lib32-v4l-utils lib32-libpulse lib32-libjpeg-turbo \
+    lib32-libxcomposite opencl-icd-loader lib32-opencl-icd-loader \
+    libxslt lib32-libxslt lib32-gtk3 && \
     pacman -Scc --noconfirm
 
 # 5. Create unprivileged user (needed for AUR builds)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,56 @@ Then compile and run:
 cargo run --release -- /path/to/config.toml
 ```
 
+### Docker / Podman
+
+The included `Dockerfile` builds a self-contained Arch Linux image with Steam, Lutris, and ES-DE pre-installed. It supports AMD, NVIDIA, and Intel GPUs out of the box and runs unprivileged.
+
+**Build the image:**
+
+```sh
+docker build -t moonshine .
+```
+
+**Run (AMD / Intel GPU):**
+
+```sh
+docker run -d \
+    --name moonshine \
+    --net host \
+    --ipc host \
+    --device /dev/dri \
+    --device /dev/uinput \
+    -e HOST_UID=$(id -u) \
+    -e HOST_GID=$(id -g) \
+    -v /dev/shm:/dev/shm \
+    -v ~/.local/share/Steam:/home/moonshine/.local/share/Steam \
+    -v ~/.local/share/lutris:/home/moonshine/.local/share/lutris \
+    -v ~/.config/moonshine:/home/moonshine/.config/moonshine \
+    moonshine
+```
+
+**Run (NVIDIA GPU):**
+
+Add `--gpus all` instead of `--device /dev/dri` (requires [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host):
+
+```sh
+docker run -d \
+    --name moonshine \
+    --net host \
+    --ipc host \
+    --gpus all \
+    --device /dev/uinput \
+    -e HOST_UID=$(id -u) \
+    -e HOST_GID=$(id -g) \
+    -v /dev/shm:/dev/shm \
+    -v ~/.local/share/Steam:/home/moonshine/.local/share/Steam \
+    -v ~/.local/share/lutris:/home/moonshine/.local/share/lutris \
+    -v ~/.config/moonshine:/home/moonshine/.config/moonshine \
+    moonshine
+```
+
+The container works on fully headless servers — no display server or audio daemon is required on the host. A default `config.toml` is created automatically on first run.
+
 ## Configuration
 
 A configuration file is created automatically if the path you provide doesn't exist.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,35 +1,62 @@
 #!/bin/bash
+# Pre-systemd initialization.
+# This runs as root before exec'ing into systemd (PID 1).
+# Dynamic setup that depends on the runtime environment (host UID,
+# GPU devices) must happen here because it can't be baked into the image.
 
-# Update UID/GID to match host (passed via environment variables)
+set -e
+
 USER_ID=${HOST_UID:-1000}
 GROUP_ID=${HOST_GID:-1000}
 
+# Remap the container user to match the host UID/GID if needed.
 if [ "$USER_ID" != "1000" ]; then
-    groupmod -g $GROUP_ID moonshine
-    usermod -u $USER_ID -g $GROUP_ID moonshine
+    groupmod -g "$GROUP_ID" moonshine 2>/dev/null || true
+    usermod -u "$USER_ID" -g "$GROUP_ID" moonshine
 fi
 
-# Unconditionally take ownership of the home directory
-# so that docker-created bind mounts get the correct permissions.
-chown -R $USER_ID:$GROUP_ID /home/moonshine
+# Fix ownership of home directory and any bind-mounted paths within it.
+chown -R "$USER_ID:$GROUP_ID" /home/moonshine
 
-# Ensure D-Bus and Avahi are running for zeroconf discovery
-mkdir -p /run/dbus /var/run/avahi-daemon
-if [ ! -S /run/dbus/system_bus_socket ]; then
-    dbus-daemon --system --fork
+# Create XDG_RUNTIME_DIR (systemd-logind does this on a real system,
+# but in a minimal container it may not be fully functional).
+mkdir -p "/run/user/$USER_ID"
+chown "$USER_ID:$GROUP_ID" "/run/user/$USER_ID"
+chmod 700 "/run/user/$USER_ID"
+
+# Create XWayland socket directory.
+mkdir -p /tmp/.X11-unix
+chmod 1777 /tmp/.X11-unix
+
+# Dynamically add the moonshine user to groups that own GPU and input devices.
+# Device files passed via --device retain their host GIDs, which won't match
+# the container's named groups.
+ensure_device_access() {
+    local dev="$1"
+    if [ -e "$dev" ]; then
+        local dev_gid
+        dev_gid=$(stat -c '%g' "$dev")
+        if ! id -G moonshine | tr ' ' '\n' | grep -qx "$dev_gid"; then
+            groupadd -g "$dev_gid" -o "hostdev_${dev_gid}" 2>/dev/null || true
+            usermod -aG "hostdev_${dev_gid}" moonshine
+        fi
+    fi
+}
+
+for dev in /dev/dri/card* /dev/dri/renderD*; do
+    ensure_device_access "$dev"
+done
+ensure_device_access /dev/uinput
+
+# Auto-detect GPU vendor and disable conflicting EGL/Vulkan ICDs.
+# nvidia-utils registers an EGL vendor that fails fatally when no NVIDIA GPU
+# is present, preventing Mesa (AMD/Intel) from initializing.
+if [ ! -e /dev/nvidia0 ] && [ ! -d /proc/driver/nvidia ]; then
+    echo "No NVIDIA GPU detected, disabling NVIDIA EGL/Vulkan ICDs."
+    rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+    rm -f /usr/share/vulkan/icd.d/nvidia_icd.json
+    rm -f /usr/share/vulkan/implicit_layer.d/nvidia_layers.json
 fi
-if ! pgrep -x "avahi-daemon" > /dev/null; then
-    avahi-daemon --daemonize --no-drop-root
-fi
 
-# Create XDG_RUNTIME_DIR to prevent PulseAudio socket permission errors
-mkdir -p /run/user/$USER_ID
-chown -R $USER_ID:$GROUP_ID /run/user/$USER_ID
-
-# Set proper environment variables for the unprivileged user before preserving them
-export HOME=/home/moonshine
-export USER=moonshine
-export XDG_RUNTIME_DIR=/run/user/$USER_ID
-
-# Execute CMD as the unprivileged user
-exec sudo -E -u moonshine -- "$@"
+# Hand off to systemd as PID 1.
+exec /usr/lib/systemd/systemd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Update UID/GID to match host (passed via environment variables)
+USER_ID=${HOST_UID:-1000}
+GROUP_ID=${HOST_GID:-1000}
+
+if [ "$USER_ID" != "1000" ]; then
+    groupmod -g $GROUP_ID moonshine
+    usermod -u $USER_ID -g $GROUP_ID moonshine
+    chown -R $USER_ID:$GROUP_ID /home/moonshine
+fi
+
+# Ensure D-Bus is running for the user session
+mkdir -p /run/dbus
+if [ ! -S /run/dbus/system_bus_socket ]; then
+    dbus-daemon --system --fork
+fi
+
+# Execute CMD as the unprivileged user
+exec gosu moonshine "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,4 +17,4 @@ if [ ! -S /run/dbus/system_bus_socket ]; then
 fi
 
 # Execute CMD as the unprivileged user
-exec gosu moonshine "$@"
+exec sudo -E -u moonshine -- "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# Pre-systemd initialization.
-# This runs as root before exec'ing into systemd (PID 1).
-# Dynamic setup that depends on the runtime environment (host UID,
-# GPU devices) must happen here because it can't be baked into the image.
+# Moonshine container entrypoint.
+# Sets up the runtime environment and launches moonshine directly.
+# Uses a systemd-run shim to avoid requiring a full systemd instance.
 
 set -e
 
@@ -18,8 +17,18 @@ fi
 # Fix ownership of home directory and any bind-mounted paths within it.
 chown -R "$USER_ID:$GROUP_ID" /home/moonshine
 
-# Create XDG_RUNTIME_DIR (systemd-logind does this on a real system,
-# but in a minimal container it may not be fully functional).
+# Start D-Bus system bus (required by avahi).
+mkdir -p /run/dbus
+if [ ! -S /run/dbus/system_bus_socket ]; then
+    dbus-daemon --system --fork
+fi
+
+# Start Avahi for zeroconf/mDNS discovery.
+if ! pgrep -x "avahi-daemon" > /dev/null; then
+    avahi-daemon --daemonize --no-drop-root 2>/dev/null || true
+fi
+
+# Create XDG_RUNTIME_DIR.
 mkdir -p "/run/user/$USER_ID"
 chown "$USER_ID:$GROUP_ID" "/run/user/$USER_ID"
 chmod 700 "/run/user/$USER_ID"
@@ -29,8 +38,6 @@ mkdir -p /tmp/.X11-unix
 chmod 1777 /tmp/.X11-unix
 
 # Dynamically add the moonshine user to groups that own GPU and input devices.
-# Device files passed via --device retain their host GIDs, which won't match
-# the container's named groups.
 ensure_device_access() {
     local dev="$1"
     if [ -e "$dev" ]; then
@@ -49,8 +56,6 @@ done
 ensure_device_access /dev/uinput
 
 # Auto-detect GPU vendor and disable conflicting EGL/Vulkan ICDs.
-# nvidia-utils registers an EGL vendor that fails fatally when no NVIDIA GPU
-# is present, preventing Mesa (AMD/Intel) from initializing.
 if [ ! -e /dev/nvidia0 ] && [ ! -d /proc/driver/nvidia ]; then
     echo "No NVIDIA GPU detected, disabling NVIDIA EGL/Vulkan ICDs."
     rm -f /usr/share/glvnd/egl_vendor.d/10_nvidia.json
@@ -58,5 +63,17 @@ if [ ! -e /dev/nvidia0 ] && [ ! -d /proc/driver/nvidia ]; then
     rm -f /usr/share/vulkan/implicit_layer.d/nvidia_layers.json
 fi
 
-# Hand off to systemd as PID 1.
-exec /usr/lib/systemd/systemd
+# Set environment for the unprivileged user.
+export HOME=/home/moonshine
+export USER=moonshine
+export XDG_RUNTIME_DIR="/run/user/$USER_ID"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$USER_ID/bus"
+export RUST_LOG="${RUST_LOG:-info}"
+
+# Start a session D-Bus bus for the user (needed by applications like Steam).
+sudo -u moonshine dbus-daemon --session \
+    --address="$DBUS_SESSION_BUS_ADDRESS" \
+    --fork --print-pid 2>/dev/null || true
+
+# Execute moonshine as the unprivileged user.
+exec sudo -E -u moonshine -- "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,14 +7,29 @@ GROUP_ID=${HOST_GID:-1000}
 if [ "$USER_ID" != "1000" ]; then
     groupmod -g $GROUP_ID moonshine
     usermod -u $USER_ID -g $GROUP_ID moonshine
-    chown -R $USER_ID:$GROUP_ID /home/moonshine
 fi
 
-# Ensure D-Bus is running for the user session
-mkdir -p /run/dbus
+# Unconditionally take ownership of the home directory
+# so that docker-created bind mounts get the correct permissions.
+chown -R $USER_ID:$GROUP_ID /home/moonshine
+
+# Ensure D-Bus and Avahi are running for zeroconf discovery
+mkdir -p /run/dbus /var/run/avahi-daemon
 if [ ! -S /run/dbus/system_bus_socket ]; then
     dbus-daemon --system --fork
 fi
+if ! pgrep -x "avahi-daemon" > /dev/null; then
+    avahi-daemon --daemonize --no-drop-root
+fi
+
+# Create XDG_RUNTIME_DIR to prevent PulseAudio socket permission errors
+mkdir -p /run/user/$USER_ID
+chown -R $USER_ID:$GROUP_ID /run/user/$USER_ID
+
+# Set proper environment variables for the unprivileged user before preserving them
+export HOME=/home/moonshine
+export USER=moonshine
+export XDG_RUNTIME_DIR=/run/user/$USER_ID
 
 # Execute CMD as the unprivileged user
 exec sudo -E -u moonshine -- "$@"

--- a/systemd-run-shim.sh
+++ b/systemd-run-shim.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Shim that replaces systemd-run for container use.
+# Moonshine calls: systemd-run --user --scope --collect --unit moonshine-session --property=... -- <program> <args>
+# We strip all systemd-run flags and just exec the actual command.
+
+while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "--" ]]; then
+        shift
+        break
+    fi
+    shift
+done
+
+exec "$@"


### PR DESCRIPTION
Hi! I thought this would be especially useful in a container with Steam, Lutris, and ES-DE. I've set that up here, it works well with my limited testing (AMD, Fedora 44, in Podman).

Currently, it installs the stable moonshine and ES-DE from the AUR, this can be changed to git if that is preferred. Further, we could save significant space by making two Dockerfiles, as the NVIDIA one has several extra dependencies, but I figured it would be easier/best to target all platforms in one.

The other unusual thing I did was add a systemd-run shim to make it unnecessary to have systemd running in the container, which can be cumbersome to manage.

Let me know if anyone has any feedback, or even if this isn't needed at this time, I just thought I'd share since I'll likely keep using this.