### PR TITLE
feat(release): add binary and vulkan layer to release assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,11 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
+  DEBIAN_FRONTEND: noninteractive
 
 permissions:
   contents: write
@@ -13,22 +15,45 @@ permissions:
 jobs:
   build:
     name: Build binary
-    runs-on: ubuntu-latest
-
-    container:
-      image: archlinux:base-devel
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install dependencies
-      uses: ./.github/actions/install-dependencies
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          clang \
+          cmake \
+          git \
+          libc++-dev \
+          libc++abi-dev \
+          libdrm-dev \
+          libevdev-dev \
+          libgbm-dev \
+          libopus-dev \
+          libwayland-dev \
+          libxkbcommon-dev \
+          pkg-config
+      shell: bash
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
 
     - name: Build
+      run: cargo build --release --workspace
+      shell: bash
+
+    - name: Inspect runtime dependencies
       run: |
-        source /etc/profile
-        cargo build --release
+        echo "::group::moonshine ldd"
+        ldd target/release/moonshine
+        echo "::endgroup::"
+        echo "::group::libmoonshine_wsi.so ldd"
+        ldd target/release/libmoonshine_wsi.so
+        echo "::endgroup::"
       shell: bash
 
     - name: Compress
@@ -36,10 +61,14 @@ jobs:
         mkdir "$RUNNER_TEMP/$GITHUB_REF_NAME"
         cp -r ./target/release/moonshine README.md "$RUNNER_TEMP/$GITHUB_REF_NAME"
         cp LICENSE "$RUNNER_TEMP/$GITHUB_REF_NAME/LICENSE"
+        cp ./target/release/libmoonshine_wsi.so "$RUNNER_TEMP/$GITHUB_REF_NAME/"
         tar caf "./moonshine-$GITHUB_REF_NAME-linux-amd64.tar.xz" -C "$RUNNER_TEMP" "$GITHUB_REF_NAME"
 
     - name: Release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: "./moonshine-*.tar.xz"
+        files: |
+          ./moonshine-*.tar.xz
+          ./target/release/moonshine
+          ./target/release/libmoonshine_wsi.so

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ sudo pacman -S \
    opus \
    pkg-config \
    rust \
-   shaderc \
    vulkan-headers \
    wayland
 ```


### PR DESCRIPTION
- Adds prebuilt binary to release assets
- Adds vulkan layer to release assets
- Moves CI to run on ubuntu 22.04 (better compatibility for unlinked deps on prebuilt binaries)
- Source builds shaderc during build to static link, since this currently the most likely dependency that will be inconsistent across host systems

@hgaiser this should be a first step to make distribution outside of AUR easier, that way whatever system gets used, there's an easy way to fetch binary and vulkan layer from the latest release rather than needing to build from source every time