### PR TITLE
Fix PulseAudio stream deadlock causing audio to cut out permanently

### DIFF
--- a/src/session/stream/audio/pulse_server/mod.rs
+++ b/src/session/stream/audio/pulse_server/mod.rs
@@ -478,18 +478,26 @@ impl PulseServer {
 					}
 				}
 
-				let bytes_needed = (stream.buffer_attr.target_length as usize)
-					.saturating_sub(stream.buffer.len_bytes() + stream.requested_bytes);
+				let min_req = stream.buffer_attr.minimum_request_length as usize;
+				let buf_len = stream.buffer.len_bytes();
+				let target = stream.buffer_attr.target_length as usize;
+				let bytes_needed = target.saturating_sub(buf_len + stream.requested_bytes);
 				if matches!(stream.state, StreamState::Playing | StreamState::Corked)
-					&& bytes_needed >= stream.buffer_attr.minimum_request_length as usize
+					&& (bytes_needed >= min_req || buf_len < min_req)
 				{
-					stream.requested_bytes += bytes_needed;
+					// Reset pending requests if buffer is critically low to avoid
+					// a deadlock where unfulfilled requests block new ones forever.
+					if buf_len < min_req {
+						stream.requested_bytes = 0;
+					}
+					let req = target.saturating_sub(buf_len + stream.requested_bytes);
+					stream.requested_bytes += req;
 					pulse::write_command_message(
 						&mut client.socket,
 						u32::MAX,
 						&pulse::Command::Request(pulse::Request {
 							channel: *id,
-							length: bytes_needed as u32,
+							length: req as u32,
 						}),
 						client.protocol_version,
 					)?;


### PR DESCRIPTION
When streaming games through Wine/Proton (via Lutris, etc.), audio would intermittently cut out entirely or cycle between "audio burst → silence → audio burst" sounding robotic/laggy. The issue was a deadlock in the PulseServer's Request mechanism.

The server tracks pending byte Requests via `requested_bytes`. If a client pauses or slows down its writes (which winepulse does during loading screens, menu transitions, etc.), `requested_bytes` accumulates past `target_length`. Once that happens, `bytes_needed` becomes `0` and the server stops sending Request commands entirely, even after the buffer drains to empty. The client never gets asked for data again, so audio stays silent forever (or until the next reconnection cycle).

The fix resets `requested_bytes` to 0 whenever the buffer falls below `minimum_request_length`, ensuring a fresh Request is always dispatched when the client runs low on data.