### PR TITLE
Scroll: normalizing scroll speed, particularly for macOS clients + using the discrete wayland scroll protocol

### DIFF
--- a/src/session/compositor/input.rs
+++ b/src/session/compositor/input.rs
@@ -13,6 +13,17 @@ use smithay::wayland::pointer_constraints::{with_pointer_constraint, PointerCons
 
 use super::state::MoonshineCompositor;
 
+/// Wheel tick size matching Windows WHEEL_DELTA convention.
+/// Moonlight clients send scroll deltas in high-res units where
+/// 120 = one scroll notch. These are accumulated until reaching
+/// this threshold before emitting a scroll tick.
+const WHEEL_DELTA: i32 = 120;
+
+/// Wayland axis value for one scroll notch.
+/// libinput convention: one notch = 15 (degrees rotation for a 15° click-angle wheel).
+/// See: https://wayland.freedesktop.org/libinput/doc/latest/wheel-api.html
+const AXIS_STEP: f64 = 15.0;
+
 /// Input events sent from the control stream to the compositor.
 ///
 /// These are transport-level events that cross the tokio→calloop boundary.
@@ -210,18 +221,43 @@ pub fn process_input(event: CompositorInputEvent, state: &mut MoonshineComposito
 			pointer.frame(state);
 		},
 		CompositorInputEvent::ScrollVertical { amount } => {
-			tracing::trace!(target: "input", "Scroll vertical: {amount}");
+			tracing::trace!(target: "input", "Scroll vertical: raw={amount}, accumulated={}", state.accumulated_vscroll_delta);
 
-			let pointer = state.seat.get_pointer().expect("pointer should exist");
-			pointer.axis(state, AxisFrame::new(time).value(Axis::Vertical, -(amount as f64)));
-			pointer.frame(state);
+			// Reset accumulation on direction change so leftover from one
+			// direction doesn't absorb the first event of the opposite direction
+			if state.accumulated_vscroll_delta != 0 &&
+				(state.accumulated_vscroll_delta > 0) != (amount > 0)
+			{
+				state.accumulated_vscroll_delta = 0;
+			}
+			state.accumulated_vscroll_delta += amount as i32;
+			let full_ticks = state.accumulated_vscroll_delta / WHEEL_DELTA;
+			if full_ticks != 0 {
+				tracing::trace!(target: "input", "Scroll vertical: emitting {full_ticks} ticks, remainder={}", state.accumulated_vscroll_delta - full_ticks * WHEEL_DELTA);
+				let pointer = state.seat.get_pointer().expect("pointer should exist");
+				// Negate for Wayland axis convention (positive = scroll up)
+				pointer.axis(state, AxisFrame::new(time).value(Axis::Vertical, -(full_ticks as f64 * AXIS_STEP)));
+				pointer.frame(state);
+				state.accumulated_vscroll_delta -= full_ticks * WHEEL_DELTA;
+			}
 		},
 		CompositorInputEvent::ScrollHorizontal { amount } => {
-			tracing::trace!(target: "input", "Scroll horizontal: {amount}");
+			tracing::trace!(target: "input", "Scroll horizontal: raw={amount}, accumulated={}", state.accumulated_hscroll_delta);
 
-			let pointer = state.seat.get_pointer().expect("pointer should exist");
-			pointer.axis(state, AxisFrame::new(time).value(Axis::Horizontal, amount as f64));
-			pointer.frame(state);
+			if state.accumulated_hscroll_delta != 0 &&
+				(state.accumulated_hscroll_delta > 0) != (amount > 0)
+			{
+				state.accumulated_hscroll_delta = 0;
+			}
+			state.accumulated_hscroll_delta += amount as i32;
+			let full_ticks = state.accumulated_hscroll_delta / WHEEL_DELTA;
+			if full_ticks != 0 {
+				tracing::trace!(target: "input", "Scroll horizontal: emitting {full_ticks} ticks, remainder={}", state.accumulated_hscroll_delta - full_ticks * WHEEL_DELTA);
+				let pointer = state.seat.get_pointer().expect("pointer should exist");
+				pointer.axis(state, AxisFrame::new(time).value(Axis::Horizontal, full_ticks as f64 * AXIS_STEP));
+				pointer.frame(state);
+				state.accumulated_hscroll_delta -= full_ticks * WHEEL_DELTA;
+			}
 		},
 	}
 }

--- a/src/session/compositor/input.rs
+++ b/src/session/compositor/input.rs
@@ -236,7 +236,7 @@ pub fn process_input(event: CompositorInputEvent, state: &mut MoonshineComposito
 				tracing::trace!(target: "input", "Scroll vertical: emitting {full_ticks} ticks, remainder={}", state.accumulated_vscroll_delta - full_ticks * WHEEL_DELTA);
 				let pointer = state.seat.get_pointer().expect("pointer should exist");
 				// Negate for Wayland axis convention (positive = scroll up)
-				pointer.axis(state, AxisFrame::new(time).value(Axis::Vertical, -(full_ticks as f64 * AXIS_STEP)));
+				pointer.axis(state, AxisFrame::new(time).value(Axis::Vertical, -(full_ticks as f64 * AXIS_STEP)).v120(Axis::Vertical, -(full_ticks * WHEEL_DELTA)));
 				pointer.frame(state);
 				state.accumulated_vscroll_delta -= full_ticks * WHEEL_DELTA;
 			}
@@ -254,7 +254,7 @@ pub fn process_input(event: CompositorInputEvent, state: &mut MoonshineComposito
 			if full_ticks != 0 {
 				tracing::trace!(target: "input", "Scroll horizontal: emitting {full_ticks} ticks, remainder={}", state.accumulated_hscroll_delta - full_ticks * WHEEL_DELTA);
 				let pointer = state.seat.get_pointer().expect("pointer should exist");
-				pointer.axis(state, AxisFrame::new(time).value(Axis::Horizontal, full_ticks as f64 * AXIS_STEP));
+				pointer.axis(state, AxisFrame::new(time).value(Axis::Horizontal, full_ticks as f64 * AXIS_STEP).v120(Axis::Horizontal, full_ticks * WHEEL_DELTA));
 				pointer.frame(state);
 				state.accumulated_hscroll_delta -= full_ticks * WHEEL_DELTA;
 			}

--- a/src/session/compositor/state.rs
+++ b/src/session/compositor/state.rs
@@ -332,6 +332,13 @@ pub struct MoonshineCompositor {
 	/// Gamescope: `focus_t::inputFocusWindow` — where pointer/mouse events go.
 	pub pointer_focus_window: Option<smithay::desktop::Window>,
 
+	// -- Scroll accumulation --
+	/// Accumulated vertical scroll delta. Emits a scroll event when
+	/// the absolute value reaches WHEEL_DELTA (120).
+	pub accumulated_vscroll_delta: i32,
+	/// Accumulated horizontal scroll delta.
+	pub accumulated_hscroll_delta: i32,
+
 	/// Monotonically increasing damage sequence counter. Incremented on each
 	/// surface commit for game windows (app_id != 0). Used to detect when
 	/// a game window has drawn since the last focus change.
@@ -613,6 +620,8 @@ impl MoonshineCompositor {
 				map_sequence_counter: 0,
 				last_keyboard_focus_window: None,
 				x11_focus: None,
+				accumulated_vscroll_delta: 0,
+				accumulated_hscroll_delta: 0,
 				focus_state: super::focus::FocusState::default(),
 				window_metadata: HashMap::new(),
 				transient_children: std::collections::HashMap::new(),


### PR DESCRIPTION
When connecting from a macOS client (trackpad or mouse), every little scroll tick moved way too far, like 12 steps instead of 1. Sunshine felt much better. Inspecting the codebase of both, Sunshine is indeed doing something special about it, but given moonshine uses wayland directly, we need a different strategy.

My own fix introduced a bug where scrolling one direction then switching (e.g. down 4× then up) would make the first scroll in the new direction do nothing. That's fixed too in the same commit.

Now scrolling feels smooth, controlled, and direction changes work on the first scroll. Maybe even better than Sunshine?

I have no other client devices to test this further though. Only macOS. It should work properly on other clients, I guess.


---

Added a second fix: scroll events were not passed correctly to games/apps running under gamescope with `--backend wayland`.

Scroll events used the basic `wl_pointer.axis` event. Some Wayland clients (like the previously mentioned gamescope) ignore the basic axis event and rely on the newer discrete/high-resolution scroll protocol events. So this second commit adds `axis_value120` and `axis_discrete` alongside the basic event so scrolls reach every client regardless of which protocol version they use.