### PR TITLE
fix: bind webserver dual-stack so IPv4 and IPv6 clients both reach it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,6 +2425,7 @@ dependencies = [
  "shellexpand",
  "shlex",
  "smithay",
+ "socket2 0.5.10",
  "steamlocate",
  "strum_macros",
  "tempfile",

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -52,6 +52,7 @@ hyper = { version = "1.8.1", features = ["server", "http1"] }
 hyper-util = { version = "0.1.20", features = ["tokio"] }
 http-body-util = "0.1.3"
 network-interface = "2.0.5"
+socket2 = "0.5.10"
 url = "2.5.8"
 notify-rust = "4.12.0"
 

--- a/moonshine-core/src/config.rs
+++ b/moonshine-core/src/config.rs
@@ -94,9 +94,9 @@ impl Default for Config {
 	fn default() -> Self {
 		Self {
 			name: "Moonshine".to_string(),
-			// Bind dual-stack by default so clients can reach us over IPv4 or IPv6.
-			// The webserver disables IPV6_V6ONLY, so this single address covers both.
-			address: "::".to_string(),
+			// IPv4-only by default; set to `::` to bind dual-stack (the webserver
+			// disables IPV6_V6ONLY, so that single address covers both).
+			address: "0.0.0.0".to_string(),
 			webserver: Default::default(),
 			stream: Default::default(),
 			applications: vec![ApplicationConfig {

--- a/moonshine-core/src/config.rs
+++ b/moonshine-core/src/config.rs
@@ -17,6 +17,31 @@ fn default_launch_timeout() -> u64 {
 	2
 }
 
+fn default_stream_use_ipv6() -> StreamUseIpv6 {
+	StreamUseIpv6::No
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamUseIpv6 {
+	/// Always advertise an IPv4 session URL to clients.
+	No,
+
+	/// Always advertise an IPv6 session URL to clients.
+	Yes,
+
+	/// Advertise the same address family the client used for the launch/resume web request.
+	/// If Moonlight launches over IPv4, it receives an IPv4 RTSP URL; if it launches
+	/// over IPv6, it receives an IPv6 RTSP URL.
+	Auto,
+}
+
+impl Default for StreamUseIpv6 {
+	fn default() -> Self {
+		Self::No
+	}
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
 	/// Name of the Moonshine host.
@@ -24,6 +49,10 @@ pub struct Config {
 
 	/// Address to bind to.
 	pub address: String,
+
+	/// Whether to advertise IPv6 session URLs to clients.
+	#[serde(default = "default_stream_use_ipv6")]
+	pub stream_use_ipv6: StreamUseIpv6,
 
 	/// Configuration for the webserver.
 	pub webserver: WebserverConfig,
@@ -106,6 +135,7 @@ impl Default for Config {
 			// Bind dual-stack by default so clients can reach us over IPv4 or IPv6.
 			// The webserver disables IPV6_V6ONLY, so this single address covers both.
 			address: "::".to_string(),
+			stream_use_ipv6: StreamUseIpv6::default(),
 			webserver: Default::default(),
 			stream: Default::default(),
 			applications: vec![ApplicationConfig {

--- a/moonshine-core/src/config.rs
+++ b/moonshine-core/src/config.rs
@@ -8,31 +8,6 @@ use crate::session::compositor::CompositorConfig;
 use crate::session::stream::StreamConfig;
 use crate::webserver::WebserverConfig;
 
-fn default_stream_use_ipv6() -> StreamUseIpv6 {
-	StreamUseIpv6::No
-}
-
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum StreamUseIpv6 {
-	/// Always advertise an IPv4 session URL to clients.
-	No,
-
-	/// Always advertise an IPv6 session URL to clients.
-	Yes,
-
-	/// Advertise the same address family the client used for the launch/resume web request.
-	/// If Moonlight launches over IPv4, it receives an IPv4 RTSP URL; if it launches
-	/// over IPv6, it receives an IPv6 RTSP URL.
-	Auto,
-}
-
-impl Default for StreamUseIpv6 {
-	fn default() -> Self {
-		Self::No
-	}
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -40,11 +15,9 @@ pub struct Config {
 	pub name: String,
 
 	/// Address to bind to.
+	///
+	/// Use IPv4 (eg. `0.0.0.0`) for IPv4-only, or IPv6 (eg. `::`) for dual-stack (IPv4 + IPv6).
 	pub address: String,
-
-	/// Whether to advertise IPv6 session URLs to clients.
-	#[serde(default = "default_stream_use_ipv6")]
-	pub stream_use_ipv6: StreamUseIpv6,
 
 	/// Configuration for the webserver.
 	pub webserver: WebserverConfig,
@@ -124,7 +97,6 @@ impl Default for Config {
 			// Bind dual-stack by default so clients can reach us over IPv4 or IPv6.
 			// The webserver disables IPV6_V6ONLY, so this single address covers both.
 			address: "::".to_string(),
-			stream_use_ipv6: StreamUseIpv6::default(),
 			webserver: Default::default(),
 			stream: Default::default(),
 			applications: vec![ApplicationConfig {

--- a/moonshine-core/src/config.rs
+++ b/moonshine-core/src/config.rs
@@ -103,7 +103,9 @@ impl Default for Config {
 	fn default() -> Self {
 		Self {
 			name: "Moonshine".to_string(),
-			address: "0.0.0.0".to_string(),
+			// Bind dual-stack by default so clients can reach us over IPv4 or IPv6.
+			// The webserver disables IPV6_V6ONLY, so this single address covers both.
+			address: "::".to_string(),
 			webserver: Default::default(),
 			stream: Default::default(),
 			applications: vec![ApplicationConfig {

--- a/moonshine-core/src/webserver/mod.rs
+++ b/moonshine-core/src/webserver/mod.rs
@@ -20,6 +20,7 @@ use image::imageops::FilterType;
 use image::ImageFormat;
 use network_interface::NetworkInterfaceConfig;
 use sha2::{Digest, Sha256};
+use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::TcpListener;
 
 use crate::{
@@ -116,8 +117,7 @@ impl Webserver {
 				let _ = shutdown
 					.wrap_cancel(
 						shutdown.wrap_trigger_shutdown(ShutdownReason::HttpShutdown, async move {
-							let listener = TcpListener::bind(http_address)
-								.await
+							let listener = bind_listener(http_address)
 								.map_err(|e| tracing::error!("Failed to bind to address {http_address}: {e}"))?;
 
 							tracing::debug!("HTTP server listening for connections on {http_address}");
@@ -128,7 +128,7 @@ impl Webserver {
 									.map_err(|e| tracing::error!("Failed to accept connection: {e}"))?;
 								tracing::trace!("Accepted connection from {address}.");
 
-								let address = connection.local_addr().ok();
+								let address = connection.local_addr().ok().map(unmap_v4_mapped);
 								let mac_address = if let Some(address) = address {
 									get_mac_address(address.ip()).unwrap_or(None)
 								} else {
@@ -199,8 +199,7 @@ impl Webserver {
 				let _ = shutdown
 					.wrap_cancel(
 						shutdown.wrap_trigger_shutdown(ShutdownReason::HttpsShutdown, async move {
-							let listener = TcpListener::bind(https_address)
-								.await
+							let listener = bind_listener(https_address)
 								.map_err(|e| tracing::error!("Failed to bind to address '{:?}': {e}", https_address))?;
 							let acceptor =
 								TlsAcceptor::from_config(config.webserver.certificate, config.webserver.private_key)?;
@@ -213,7 +212,7 @@ impl Webserver {
 									.map_err(|e| tracing::error!("Failed to accept connection: {e}"))?;
 								tracing::trace!("Accepted TLS connection from {address}.");
 
-								let address = connection.local_addr().ok();
+								let address = connection.local_addr().ok().map(unmap_v4_mapped);
 								let mac_address = if let Some(address) = address {
 									get_mac_address(address.ip()).unwrap_or(None)
 								} else {
@@ -824,7 +823,7 @@ impl Webserver {
 		if let Some(addr) = local_address {
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				addr.ip(),
+				rtsp_host(addr.ip()),
 				self.config.stream.port
 			);
 		}
@@ -898,7 +897,7 @@ impl Webserver {
 		if let Some(addr) = local_address {
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				addr.ip(),
+				rtsp_host(addr.ip()),
 				self.config.stream.port
 			);
 		}
@@ -949,6 +948,45 @@ impl Webserver {
 				Some(unauthorized("No client certificate provided."))
 			},
 		}
+	}
+}
+
+/// Bind a TCP listener for the webserver. When the address is IPv6 we disable
+/// `IPV6_V6ONLY` so the single socket also accepts IPv4-mapped connections. This
+/// lets clients reach us over whichever family mDNS advertised (avahi publishes
+/// both an A and AAAA record), avoiding the "online/offline" flip-flop that
+/// happens when one family has no listener.
+fn bind_listener(address: SocketAddr) -> std::io::Result<TcpListener> {
+	let socket = Socket::new(Domain::for_address(address), Type::STREAM, Some(Protocol::TCP))?;
+	if address.is_ipv6() {
+		socket.set_only_v6(false)?;
+	}
+	socket.set_reuse_address(true)?;
+	socket.bind(&address.into())?;
+	socket.listen(1024)?;
+	socket.set_nonblocking(true)?;
+	TcpListener::from_std(socket.into())
+}
+
+/// Collapse an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) back to plain IPv4.
+/// Connections arriving over IPv4 on a dual-stack socket report such an address;
+/// normalizing keeps MAC lookups and session URLs using the real IPv4 address.
+fn unmap_v4_mapped(addr: SocketAddr) -> SocketAddr {
+	match addr.ip() {
+		IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+			Some(v4) => SocketAddr::new(IpAddr::V4(v4), addr.port()),
+			None => addr,
+		},
+		IpAddr::V4(_) => addr,
+	}
+}
+
+/// Format an IP address for use as the host part of an RTSP URL. IPv6 addresses
+/// must be wrapped in brackets (`rtsp://[::1]:48010`) to be a valid URL.
+fn rtsp_host(ip: IpAddr) -> String {
+	match ip {
+		IpAddr::V4(v4) => v4.to_string(),
+		IpAddr::V6(v6) => format!("[{v6}]"),
 	}
 }
 

--- a/moonshine-core/src/webserver/mod.rs
+++ b/moonshine-core/src/webserver/mod.rs
@@ -25,7 +25,6 @@ use tokio::net::TcpListener;
 
 use crate::{
 	clients::ClientManager,
-	config::StreamUseIpv6,
 	session::{
 		application::ApplicationConfig, compositor::CompositorConfig, manager::SessionManager, SessionContext,
 		SessionKeyData, SessionKeys, APP_LAUNCH_HTTP_TIMEOUT_SECS,
@@ -97,9 +96,8 @@ enum ServerCodecModeSupport {
 
 #[derive(Clone)]
 pub struct Webserver {
-	hostname: String,
+	name: String,
 	rtsp_port: u16,
-	stream_use_ipv6: StreamUseIpv6,
 	webserver_config: WebserverConfig,
 	applications: Vec<ApplicationConfig>,
 	unique_id: String,
@@ -114,10 +112,9 @@ impl Webserver {
 	#[allow(clippy::result_unit_err)]
 	#[allow(clippy::too_many_arguments)]
 	pub fn new(
-		hostname: String,
+		name: String,
 		address: String,
 		rtsp_port: u16,
-		stream_use_ipv6: StreamUseIpv6,
 		webserver_config: WebserverConfig,
 		applications: Vec<ApplicationConfig>,
 		compositor_config: CompositorConfig,
@@ -133,9 +130,8 @@ impl Webserver {
 		let hdr_supported = compositor_config.hdr && super::session::compositor::probe_hdr_support(&compositor_config);
 
 		let server = Self {
-			hostname,
+			name,
 			rtsp_port,
-			stream_use_ipv6,
 			webserver_config,
 			applications,
 			unique_id,
@@ -157,7 +153,13 @@ impl Webserver {
 				)
 			})?
 			.next()
-			.ok_or_else(|| tracing::error!("Failed to resolve address '{}' port {}", address, server.webserver_config.port))?;
+			.ok_or_else(|| {
+				tracing::error!(
+					"Failed to resolve address '{}' port {}",
+					address,
+					server.webserver_config.port
+				)
+			})?;
 
 		tokio::spawn({
 			let server = server.clone();
@@ -570,7 +572,7 @@ impl Webserver {
 
 		// TODO: Check the use of some of these values, we leave most of them blank and Moonlight doesn't care.
 		let mut response = "<root status_code=\"200\">".to_string();
-		response += &format!("<hostname>{}</hostname>", escape_xml(&self.hostname));
+		response += &format!("<hostname>{}</hostname>", escape_xml(&self.name));
 		response += &format!("<appversion>{}</appversion>", SERVERINFO_APP_VERSION);
 		response += &format!("<GfeVersion>{}</GfeVersion>", SERVERINFO_GFE_VERSION);
 		response += &format!("<uniqueid>{}</uniqueid>", self.unique_id);
@@ -858,10 +860,9 @@ impl Webserver {
 		let mut response = "<root status_code=\"200\">".to_string();
 		response += "<gamesession>1</gamesession>";
 		if let Some(addr) = local_address {
-			let session_ip = session_url_ip(self.stream_use_ipv6, addr);
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				rtsp_host(session_ip),
+				rtsp_host(addr.ip()),
 				self.rtsp_port
 			);
 		}
@@ -933,10 +934,9 @@ impl Webserver {
 
 		let mut response = "<root status_code=\"200\">".to_string();
 		if let Some(addr) = local_address {
-			let session_ip = session_url_ip(self.stream_use_ipv6, addr);
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				rtsp_host(session_ip),
+				rtsp_host(addr.ip()),
 				self.rtsp_port
 			);
 		}
@@ -1027,57 +1027,6 @@ fn rtsp_host(ip: IpAddr) -> String {
 		IpAddr::V4(v4) => v4.to_string(),
 		IpAddr::V6(v6) => format!("[{v6}]"),
 	}
-}
-
-fn session_url_ip(stream_use_ipv6: StreamUseIpv6, local_address: SocketAddr) -> IpAddr {
-	let local_ip = local_address.ip();
-	match stream_use_ipv6 {
-		StreamUseIpv6::Auto => local_ip,
-		StreamUseIpv6::No if local_ip.is_ipv4() => local_ip,
-		StreamUseIpv6::Yes if local_ip.is_ipv6() => local_ip,
-		StreamUseIpv6::No => interface_ip_for_family(local_ip, StreamUseIpv6::No)
-			.or_else(|| first_interface_ip(StreamUseIpv6::No))
-			.unwrap_or_else(|| {
-				tracing::warn!("Configured stream_use_ipv6 is no, but no IPv4 address was found; using {local_ip}.");
-				local_ip
-			}),
-		StreamUseIpv6::Yes => interface_ip_for_family(local_ip, StreamUseIpv6::Yes)
-			.or_else(|| first_interface_ip(StreamUseIpv6::Yes))
-			.unwrap_or_else(|| {
-				tracing::warn!("Configured stream_use_ipv6 is yes, but no IPv6 address was found; using {local_ip}.");
-				local_ip
-			}),
-	}
-}
-
-fn interface_ip_for_family(local_ip: IpAddr, stream_use_ipv6: StreamUseIpv6) -> Option<IpAddr> {
-	let interfaces = network_interface::NetworkInterface::show().ok()?;
-	for interface in interfaces {
-		if interface.addr.iter().any(|address| address.ip() == local_ip) {
-			return interface
-				.addr
-				.into_iter()
-				.map(|address| address.ip())
-				.find(|ip| ip_matches_stream_ipv6(*ip, stream_use_ipv6) && !ip.is_loopback());
-		}
-	}
-	None
-}
-
-fn first_interface_ip(stream_use_ipv6: StreamUseIpv6) -> Option<IpAddr> {
-	let interfaces = network_interface::NetworkInterface::show().ok()?;
-	interfaces
-		.into_iter()
-		.flat_map(|interface| interface.addr)
-		.map(|address| address.ip())
-		.find(|ip| ip_matches_stream_ipv6(*ip, stream_use_ipv6) && !ip.is_loopback())
-}
-
-fn ip_matches_stream_ipv6(ip: IpAddr, stream_use_ipv6: StreamUseIpv6) -> bool {
-	matches!(
-		(ip, stream_use_ipv6),
-		(IpAddr::V4(_), StreamUseIpv6::No) | (IpAddr::V6(_), StreamUseIpv6::Yes)
-	)
 }
 
 fn bad_request(message: String) -> Response<Full<Bytes>> {

--- a/moonshine-core/src/webserver/mod.rs
+++ b/moonshine-core/src/webserver/mod.rs
@@ -25,7 +25,7 @@ use tokio::net::TcpListener;
 
 use crate::{
 	clients::ClientManager,
-	config::Config,
+	config::{Config, StreamUseIpv6},
 	session::{manager::SessionManager, SessionContext, SessionKeyData, SessionKeys, APP_LAUNCH_HTTP_TIMEOUT_SECS},
 	tls::TlsAcceptor,
 };
@@ -821,9 +821,10 @@ impl Webserver {
 		let mut response = "<root status_code=\"200\">".to_string();
 		response += "<gamesession>1</gamesession>";
 		if let Some(addr) = local_address {
+			let session_ip = session_url_ip(&self.config, addr);
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				rtsp_host(addr.ip()),
+				rtsp_host(session_ip),
 				self.config.stream.port
 			);
 		}
@@ -895,9 +896,10 @@ impl Webserver {
 
 		let mut response = "<root status_code=\"200\">".to_string();
 		if let Some(addr) = local_address {
+			let session_ip = session_url_ip(&self.config, addr);
 			response += &format!(
 				"<sessionUrl0>rtsp://{}:{}</sessionUrl0>",
-				rtsp_host(addr.ip()),
+				rtsp_host(session_ip),
 				self.config.stream.port
 			);
 		}
@@ -988,6 +990,57 @@ fn rtsp_host(ip: IpAddr) -> String {
 		IpAddr::V4(v4) => v4.to_string(),
 		IpAddr::V6(v6) => format!("[{v6}]"),
 	}
+}
+
+fn session_url_ip(config: &Config, local_address: SocketAddr) -> IpAddr {
+	let local_ip = local_address.ip();
+	match config.stream_use_ipv6 {
+		StreamUseIpv6::Auto => local_ip,
+		StreamUseIpv6::No if local_ip.is_ipv4() => local_ip,
+		StreamUseIpv6::Yes if local_ip.is_ipv6() => local_ip,
+		StreamUseIpv6::No => interface_ip_for_family(local_ip, StreamUseIpv6::No)
+			.or_else(|| first_interface_ip(StreamUseIpv6::No))
+			.unwrap_or_else(|| {
+				tracing::warn!("Configured stream_use_ipv6 is no, but no IPv4 address was found; using {local_ip}.");
+				local_ip
+			}),
+		StreamUseIpv6::Yes => interface_ip_for_family(local_ip, StreamUseIpv6::Yes)
+			.or_else(|| first_interface_ip(StreamUseIpv6::Yes))
+			.unwrap_or_else(|| {
+				tracing::warn!("Configured stream_use_ipv6 is yes, but no IPv6 address was found; using {local_ip}.");
+				local_ip
+			}),
+	}
+}
+
+fn interface_ip_for_family(local_ip: IpAddr, stream_use_ipv6: StreamUseIpv6) -> Option<IpAddr> {
+	let interfaces = network_interface::NetworkInterface::show().ok()?;
+	for interface in interfaces {
+		if interface.addr.iter().any(|address| address.ip() == local_ip) {
+			return interface
+				.addr
+				.into_iter()
+				.map(|address| address.ip())
+				.find(|ip| ip_matches_stream_ipv6(*ip, stream_use_ipv6) && !ip.is_loopback());
+		}
+	}
+	None
+}
+
+fn first_interface_ip(stream_use_ipv6: StreamUseIpv6) -> Option<IpAddr> {
+	let interfaces = network_interface::NetworkInterface::show().ok()?;
+	interfaces
+		.into_iter()
+		.flat_map(|interface| interface.addr)
+		.map(|address| address.ip())
+		.find(|ip| ip_matches_stream_ipv6(*ip, stream_use_ipv6) && !ip.is_loopback())
+}
+
+fn ip_matches_stream_ipv6(ip: IpAddr, stream_use_ipv6: StreamUseIpv6) -> bool {
+	matches!(
+		(ip, stream_use_ipv6),
+		(IpAddr::V4(_), StreamUseIpv6::No) | (IpAddr::V6(_), StreamUseIpv6::Yes)
+	)
 }
 
 fn bad_request(message: String) -> Response<Full<Bytes>> {

--- a/moonshine-core/src/webserver/pairing.rs
+++ b/moonshine-core/src/webserver/pairing.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, net::{IpAddr, SocketAddr}, sync::Arc};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 
 use async_shutdown::ShutdownManager;
 use http_body_util::Full;
@@ -172,7 +172,8 @@ async fn get_server_cert(
 
 	// Emit a notification, allowing the user to automatically open the PIN page.
 	if let Some(local_address) = local_address {
-		let pin_url = format!("http://{}:{}/pin?uniqueid={}", local_address.ip(), http_port, unique_id);
+		let pin_address = SocketAddr::new(local_address.ip(), http_port);
+		let pin_url = format!("http://{pin_address}/pin?uniqueid={unique_id}");
 		tracing::info!("Waiting for pin to be sent at {pin_url}");
 
 		let _ = std::thread::Builder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,6 @@ impl Moonshine {
 				config.name.clone(),
 				config.address.clone(),
 				config.stream.port,
-				config.stream_use_ipv6,
 				config.webserver.clone(),
 				config.applications.clone(),
 				config.compositor.clone(),


### PR DESCRIPTION
## Problem

Avahi advertises the host on both IPv4 (A record) and IPv6 (AAAA record) by default, but the web server bound to `0.0.0.0` — IPv4 only. When Moonlight discovers the host via mDNS it gets both addresses and polls `/serverinfo` on each: the IPv4 poll succeeds (host shows online / padlock), while the IPv6 poll is refused (host shows offline / warning triangle). The client rotates between the two, so the host icon flip-flops between online and offline and pairing fails. This makes an auto-discovered Moonshine instance hard to connect to.

This reproduces on any machine with an IPv6 address (e.g. a router-assigned ULA) and `use-ipv6=yes` in Avahi (the default).

## Fix

- Bind the HTTP and HTTPS listeners via `socket2` with `IPV6_V6ONLY` disabled, so a single `::` socket serves both IPv4 and IPv6.
- The default `address` stays `0.0.0.0` (IPv4-only); setting it to `::` opts into dual-stack. Either way the webserver, RTSP, and streams follow the configured address consistently, so discovery and reachability can't disagree anymore.
- Bracket IPv6 hosts in the RTSP `sessionUrl0` (`rtsp://[::1]:48010`) so launch/resume URLs are valid over IPv6.
- Normalize IPv4-mapped addresses (`::ffff:a.b.c.d` → `a.b.c.d`) so MAC lookups and session URLs stay clean for IPv4 clients on the dual-stack socket.

## Testing

- `ss` shows the listeners on `*:47989` / `*:47984`, and `/serverinfo` returns `200` over both the IPv4 and the IPv6 (ULA) address. Before, the IPv6 request was refused. 

## Concerns

With the IPv4-only default, IPv6 reachability is opt-in via `address = "::"`. Pairs well with #111, which advertises only the addresses matching `config.address` — so the default no longer advertises an unreachable AAAA record, and `::` gives working dual-stack end to end (granted no network issues).
