### PR TITLE
feat: load virtual input kernel modules on startup

### DIFF
--- a/dist/moonshine-modules.conf
+++ b/dist/moonshine-modules.conf
@@ -1,0 +1,3 @@
+# Virtual input backends used by inputtino.
+uinput
+uhid


### PR DESCRIPTION
Adds a small `modules-load.d` config for the virtual input backends Moonshine uses through inputtino, so the kernel creates the devices on boot.

## Problem

The udev rule already sets permissions for `/dev/uinput` and `/dev/uhid`, and the service file already allows both devices — but that only works once the kernel has actually created them. 

I hit this with a PS4 controller over Moonlight on iPad: Moonlight reported `kind: PlayStation`, Moonshine tried to create the PS5 virtual controller, and inputtino failed to open `/dev/uhid` with `Permission denied`. Loading `uhid` fixed it immediately.

## Fix

- Add `dist/moonshine-modules.conf` to load the required modules (e.g. `uhid`) via `modules-load.d`.

The AUR `moonshine-git` PKGBUILD should install it alongside the existing service/udev files:

```sh
install -Dm644 dist/moonshine@.service "$pkgdir/usr/lib/systemd/system/moonshine@.service"
install -Dm644 dist/60-moonshine.rules "$pkgdir/usr/lib/udev/rules.d/60-moonshine.rules"
install -Dm644 dist/moonshine-modules.conf "$pkgdir/usr/lib/modules-load.d/moonshine.conf"
```

## Testing

On already-installed systems the module may need to be loaded once (or a reboot) for immediate use:

```sh
sudo modprobe uhid
sudo udevadm trigger --subsystem-match=misc
```

After that, the PS4-over-iPad case above creates the virtual controller without the `Permission denied` error.
