### PR TITLE
feat: stream scRGB (EXTENDED_SRGB_LINEAR) HDR games like CONTROL as BT.2020+PQ

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,8 +2829,8 @@ dependencies = [
 
 [[package]]
 name = "pixelforge"
-version = "0.3.0"
-source = "git+https://github.com/lutyjj/pixelforge?rev=e870cfd587ff52a18d74493a84991ce162274507#e870cfd587ff52a18d74493a84991ce162274507"
+version = "0.5.0"
+source = "git+https://github.com/hgaiser/pixelforge?rev=d33166e4d22e3cb8c0b9cad16be705183737174b#d33166e4d22e3cb8c0b9cad16be705183737174b"
 dependencies = [
  "ash",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,8 +2829,8 @@ dependencies = [
 
 [[package]]
 name = "pixelforge"
-version = "0.4.0"
-source = "git+https://github.com/hgaiser/pixelforge?rev=61b5e85#61b5e854cea957bf00d4cf616221dea68d7982e7"
+version = "0.3.0"
+source = "git+https://github.com/lutyjj/pixelforge?rev=e870cfd587ff52a18d74493a84991ce162274507#e870cfd587ff52a18d74493a84991ce162274507"
 dependencies = [
  "ash",
  "thiserror 1.0.69",

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -76,7 +76,7 @@ wayland-scanner = "0.31"
 
 # Session (video stream)
 # scRGB-linear→BT.2020+PQ support via the `Bt709LinearToBt2020Pq` color space (PR hgaiser/pixelforge#15).
-pixelforge = { git = "https://github.com/lutyjj/pixelforge", rev = "e870cfd587ff52a18d74493a84991ce162274507", features = ["dmabuf"] }
+pixelforge = { git = "https://github.com/hgaiser/pixelforge", rev = "d33166e4d22e3cb8c0b9cad16be705183737174b", features = ["dmabuf"] }
 
 # Session (audio stream)
 opus = "0.3.1"

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -75,7 +75,6 @@ xcursor = "0.3.10"
 wayland-scanner = "0.31"
 
 # Session (video stream)
-# scRGB-linear→BT.2020+PQ support via the `Bt709LinearToBt2020Pq` color space (PR hgaiser/pixelforge#15).
 pixelforge = { git = "https://github.com/hgaiser/pixelforge", rev = "d33166e4d22e3cb8c0b9cad16be705183737174b", features = ["dmabuf"] }
 
 # Session (audio stream)

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -75,7 +75,8 @@ xcursor = "0.3.10"
 wayland-scanner = "0.31"
 
 # Session (video stream)
-pixelforge = { git = "https://github.com/hgaiser/pixelforge", rev = "61b5e85", features = ["dmabuf"] }
+# scRGB-linear→BT.2020+PQ support via the `Bt709LinearToBt2020Pq` color space (PR hgaiser/pixelforge#15).
+pixelforge = { git = "https://github.com/lutyjj/pixelforge", rev = "e870cfd587ff52a18d74493a84991ce162274507", features = ["dmabuf"] }
 
 # Session (audio stream)
 opus = "0.3.1"

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -215,28 +215,18 @@ impl ColorManagementState {
 		self.pending.insert(surface.clone(), Some(desc));
 	}
 
-	/// Directly set the current gamescope color space for a surface,
-	/// bypassing the pending→commit flow.  Used when the surface will
-	/// never be committed (e.g. a protocol-only bypass surface).
-	pub fn set_gamescope_current(&mut self, surface: &WlSurface, desc: ImageDescription) {
-		tracing::debug!(
-			surface_id = ?surface.id(),
-			color_space = ?desc.to_frame_color_space(),
-			"set_gamescope_current (direct)"
-		);
-		self.gamescope_current.insert(surface.clone(), desc);
-	}
-
 	/// Update only the transfer function and primaries of a surface's gamescope
 	/// color description, **preserving** any HDR mastering metadata previously
-	/// set via [`set_gamescope_current`] (i.e. `vkSetHdrMetadataEXT`).
+	/// set via [`set_gamescope_hdr_metadata`] (i.e. `vkSetHdrMetadataEXT`).
 	///
 	/// `swapchain_feedback` reports the swapchain color space but carries no
-	/// mastering metadata. Calling `set_gamescope_current` from that path would
+	/// mastering metadata. Replacing the whole description from that path would
 	/// reset `max_cll`/`max_fall`/mastering luminance to `None`, discarding the
 	/// values the game provided through `vkSetHdrMetadataEXT` — which can arrive
 	/// before the colorspace event. Preserving them here ensures the client
 	/// receives the game's real HDR10 metadata instead of a generic fallback.
+	///
+	/// [`set_gamescope_hdr_metadata`]: Self::set_gamescope_hdr_metadata
 	pub fn set_gamescope_colorspace(
 		&mut self,
 		surface: &WlSurface,
@@ -254,6 +244,47 @@ impl ColorManagementState {
 			color_space = ?desc.to_frame_color_space(),
 			has_metadata = desc.max_cll.is_some() || desc.max_fall.is_some() || desc.mastering_luminance.is_some(),
 			"set_gamescope_colorspace (preserving metadata)"
+		);
+	}
+
+	/// Update only the HDR mastering metadata of a surface's gamescope color
+	/// description, **preserving** the transfer function and primaries
+	/// previously set via [`set_gamescope_colorspace`].
+	///
+	/// This is the mirror image of [`set_gamescope_colorspace`]:
+	/// `vkSetHdrMetadataEXT` carries only mastering metadata, while the
+	/// transfer function is determined by the swapchain color space. Games
+	/// like Cyberpunk 2077 set HDR metadata *after* their scRGB swapchain is
+	/// created; replacing the whole description here would mislabel the linear
+	/// scRGB buffers as PQ-encoded (over-saturating the stream). When no color
+	/// space has been declared yet, defaults to BT.2020+PQ — the DXVK HDR10
+	/// path, where the swapchain blitter outputs genuinely PQ-encoded data.
+	///
+	/// [`set_gamescope_colorspace`]: Self::set_gamescope_colorspace
+	pub fn set_gamescope_hdr_metadata(
+		&mut self,
+		surface: &WlSurface,
+		max_cll: u32,
+		max_fall: u32,
+		mastering_luminance: (u32, u32),
+		mastering_primaries: [(u32, u32); 3],
+		white_point: (u32, u32),
+	) {
+		let desc = self
+			.gamescope_current
+			.entry(surface.clone())
+			.or_insert_with(ImageDescription::bt2020_pq);
+		desc.max_cll = Some(max_cll);
+		desc.max_fall = Some(max_fall);
+		desc.mastering_luminance = Some(mastering_luminance);
+		desc.mastering_primaries = Some(mastering_primaries);
+		desc.white_point = Some(white_point);
+		tracing::debug!(
+			surface_id = ?surface.id(),
+			color_space = ?desc.to_frame_color_space(),
+			max_cll,
+			max_fall,
+			"set_gamescope_hdr_metadata (preserving colorspace)"
 		);
 	}
 
@@ -312,18 +343,21 @@ impl ColorManagementState {
 
 	/// Get HDR metadata from the current fullscreen surface, if any.
 	///
-	/// Returns `Some(HdrMetadata)` when a surface has declared BT.2020+PQ
-	/// with max_cll or max_fall values.
+	/// Returns `Some(HdrMetadata)` when a surface has declared an HDR color
+	/// space (BT.2020+PQ or scRGB-linear) together with mastering metadata.
+	/// scRGB surfaces are included because their content reaches the client
+	/// as BT.2020+PQ after conversion, so the game's metadata (e.g. from
+	/// `vkSetHdrMetadataEXT`) still describes the transported stream.
 	pub fn hdr_metadata(&self) -> Option<HdrMetadata> {
-		// Search all BT.2020+PQ surfaces (gamescope/moonshine swapchain first,
-		// then wp_color_management) for the first one that carries HDR metadata.
-		// Using only `first_bt2020pq_desc()` would stop at the first BT.2020+PQ
-		// surface even if it has no metadata while another one does.
+		// Search all HDR surfaces (gamescope/moonshine swapchain first, then
+		// wp_color_management) for the first one that carries HDR metadata —
+		// not just the first HDR surface, which may have none while another
+		// one does.
 		let desc = self
 			.gamescope_current
 			.values()
 			.chain(self.current.values())
-			.filter(|desc| desc.to_frame_color_space() == FrameColorSpace::Bt2020Pq)
+			.filter(|desc| desc.to_frame_color_space() != FrameColorSpace::Srgb)
 			.find(|desc| desc.max_cll.is_some() || desc.max_fall.is_some() || desc.mastering_luminance.is_some())?;
 		// Clamp u32 protocol values to u16 range for the Moonlight HDR metadata.
 		// Well-behaved clients stay within range; clamp rather than truncate.
@@ -358,8 +392,9 @@ impl ColorManagementState {
 	///    when toggling HDR mode, so the old surface's entry must be evicted here
 	///    — it won't be seen by `create_swapchain`, which only sees the new surface.
 	///
-	/// The HDR state will be re-established by `set_gamescope_current` if the
-	/// new swapchain calls `vkSetHdrMetadataEXT`.
+	/// The HDR state will be re-established by `set_gamescope_colorspace` /
+	/// `set_gamescope_hdr_metadata` when the new swapchain reports its color
+	/// space or calls `vkSetHdrMetadataEXT`.
 	pub fn clear_gamescope_current(&mut self, surface: &WlSurface) {
 		if self.gamescope_current.remove(surface).is_some() {
 			tracing::debug!(surface_id = ?surface.id(), "clear_gamescope_current: removed stale HDR state");

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -39,6 +39,9 @@ use crate::session::compositor::state::MoonshineCompositor;
 pub(crate) enum TransferFunction {
 	Gamma22,
 	St2084Pq,
+	/// Linear light with extended range (scRGB). Values may exceed 1.0 to
+	/// represent HDR highlights above SDR white. Paired with BT.709 primaries.
+	LinearExtended,
 }
 
 /// Color primaries as declared by a client.
@@ -91,10 +94,10 @@ impl ImageDescription {
 	}
 
 	pub fn to_frame_color_space(self) -> FrameColorSpace {
-		if self.primaries == Primaries::Bt2020 && self.transfer_function == TransferFunction::St2084Pq {
-			FrameColorSpace::Bt2020Pq
-		} else {
-			FrameColorSpace::Srgb
+		match (self.primaries, self.transfer_function) {
+			(Primaries::Bt2020, TransferFunction::St2084Pq) => FrameColorSpace::Bt2020Pq,
+			(Primaries::Srgb, TransferFunction::LinearExtended) => FrameColorSpace::Bt709Linear,
+			_ => FrameColorSpace::Srgb,
 		}
 	}
 }
@@ -212,6 +215,36 @@ impl ColorManagementState {
 		self.gamescope_current.insert(surface.clone(), desc);
 	}
 
+	/// Update only the transfer function and primaries of a surface's gamescope
+	/// color description, **preserving** any HDR mastering metadata previously
+	/// set via [`set_gamescope_current`] (i.e. `vkSetHdrMetadataEXT`).
+	///
+	/// `swapchain_feedback` reports the swapchain color space but carries no
+	/// mastering metadata. Calling `set_gamescope_current` from that path would
+	/// reset `max_cll`/`max_fall`/mastering luminance to `None`, discarding the
+	/// values the game provided through `vkSetHdrMetadataEXT` — which can arrive
+	/// before the colorspace event. Preserving them here ensures the client
+	/// receives the game's real HDR10 metadata instead of a generic fallback.
+	pub fn set_gamescope_colorspace(
+		&mut self,
+		surface: &WlSurface,
+		transfer_function: TransferFunction,
+		primaries: Primaries,
+	) {
+		let desc = self
+			.gamescope_current
+			.entry(surface.clone())
+			.or_insert_with(ImageDescription::srgb);
+		desc.transfer_function = transfer_function;
+		desc.primaries = primaries;
+		tracing::debug!(
+			surface_id = ?surface.id(),
+			color_space = ?desc.to_frame_color_space(),
+			has_metadata = desc.max_cll.is_some() || desc.max_fall.is_some() || desc.mastering_luminance.is_some(),
+			"set_gamescope_colorspace (preserving metadata)"
+		);
+	}
+
 	/// Clear the pending image description (from `unset_image_description`).
 	pub fn unset_pending(&mut self, surface: &WlSurface) {
 		self.pending.insert(surface.clone(), None);
@@ -242,27 +275,19 @@ impl ColorManagementState {
 		}
 	}
 
-	/// Find the first BT.2020+PQ image description across all tracked surfaces.
+	/// Get the frame color space for the current fullscreen surface.
 	///
-	/// Gamescope swapchain declarations are checked first (higher priority),
-	/// then wp_color_management declarations.
-	fn first_bt2020pq_desc(&self) -> Option<&ImageDescription> {
+	/// Returns the first non-sRGB color space declared by any mapped surface
+	/// (BT.2020+PQ or scRGB-linear), otherwise `Srgb`. Gamescope swapchain
+	/// declarations are checked first (higher priority), then wp_color_management
+	/// declarations.
+	pub fn frame_color_space(&self) -> FrameColorSpace {
 		self.gamescope_current
 			.values()
 			.chain(self.current.values())
-			.find(|desc| desc.to_frame_color_space() == FrameColorSpace::Bt2020Pq)
-	}
-
-	/// Get the frame color space for the current fullscreen surface.
-	///
-	/// Returns `Bt2020Pq` if any mapped surface has declared BT.2020+PQ,
-	/// otherwise returns `Srgb`.
-	pub fn frame_color_space(&self) -> FrameColorSpace {
-		if self.first_bt2020pq_desc().is_some() {
-			FrameColorSpace::Bt2020Pq
-		} else {
-			FrameColorSpace::Srgb
-		}
+			.map(|desc| desc.to_frame_color_space())
+			.find(|cs| *cs != FrameColorSpace::Srgb)
+			.unwrap_or(FrameColorSpace::Srgb)
 	}
 
 	/// Get HDR metadata from the current fullscreen surface, if any.
@@ -620,6 +645,12 @@ impl Dispatch<wp_image_description_v1::WpImageDescriptionV1, ImageDescriptionUse
 						info.tf_named(wp_color_manager_v1::TransferFunction::St2084Pq);
 						// PQ: 0–10000 cd/m², SDR reference white 203 cd/m².
 						info.luminances(0, 10000, 203);
+						info.target_luminance(0, 10000);
+					},
+					TransferFunction::LinearExtended => {
+						info.tf_named(wp_color_manager_v1::TransferFunction::ExtLinear);
+						// scRGB: linear with extended range, 1.0 == 80 cd/m² (IEC 61966-2-2).
+						info.luminances(0, 10000, 80);
 						info.target_luminance(0, 10000);
 					},
 				}

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -41,7 +41,7 @@ pub(crate) enum TransferFunction {
 	St2084Pq,
 	/// Linear light with extended range (scRGB). Values may exceed 1.0 to
 	/// represent HDR highlights above SDR white. Paired with BT.709 primaries.
-	LinearExtended,
+	ScrgbLinear,
 }
 
 /// Color primaries as declared by a client.
@@ -96,7 +96,7 @@ impl ImageDescription {
 	pub fn to_frame_color_space(self) -> FrameColorSpace {
 		match (self.primaries, self.transfer_function) {
 			(Primaries::Bt2020, TransferFunction::St2084Pq) => FrameColorSpace::Bt2020Pq,
-			(Primaries::Srgb, TransferFunction::LinearExtended) => FrameColorSpace::Bt709Linear,
+			(Primaries::Srgb, TransferFunction::ScrgbLinear) => FrameColorSpace::ScrgbLinear,
 			_ => FrameColorSpace::Srgb,
 		}
 	}
@@ -647,7 +647,7 @@ impl Dispatch<wp_image_description_v1::WpImageDescriptionV1, ImageDescriptionUse
 						info.luminances(0, 10000, 203);
 						info.target_luminance(0, 10000);
 					},
-					TransferFunction::LinearExtended => {
+					TransferFunction::ScrgbLinear => {
 						info.tf_named(wp_color_manager_v1::TransferFunction::ExtLinear);
 						// scRGB: linear with extended range, 1.0 == 80 cd/m² (IEC 61966-2-2).
 						info.luminances(0, 10000, 80);

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -52,7 +52,7 @@ pub(crate) enum Primaries {
 }
 
 /// A resolved image description created from parametric parameters.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ImageDescription {
 	pub transfer_function: TransferFunction,
 	pub primaries: Primaries,
@@ -207,7 +207,7 @@ impl ColorManagementState {
 
 	/// Set a pending image description for a surface (from `set_image_description`).
 	pub fn set_pending(&mut self, surface: &WlSurface, desc: ImageDescription) {
-		tracing::debug!(
+		tracing::trace!(
 			surface_id = ?surface.id(),
 			color_space = ?desc.to_frame_color_space(),
 			"set_pending"
@@ -299,20 +299,26 @@ impl ColorManagementState {
 		if let Some(pending) = self.pending.remove(surface) {
 			match pending {
 				Some(desc) => {
-					tracing::debug!(
-						surface_id = ?surface.id(),
-						color_space = ?desc.to_frame_color_space(),
-						num_current = self.current.len(),
-						"commit: inserting into current"
-					);
-					self.current.insert(surface.clone(), desc);
+					// Some clients (e.g. Forza Horizon via vkd3d-proton)
+					// re-set an identical description every frame; log only
+					// actual changes to keep debug output readable.
+					let prev = self.current.insert(surface.clone(), desc);
+					if prev != Some(desc) {
+						tracing::debug!(
+							surface_id = ?surface.id(),
+							color_space = ?desc.to_frame_color_space(),
+							num_current = self.current.len(),
+							"commit: inserting into current"
+						);
+					}
 				},
 				None => {
-					tracing::debug!(
-						surface_id = ?surface.id(),
-						"commit: removing from current"
-					);
-					self.current.remove(surface);
+					if self.current.remove(surface).is_some() {
+						tracing::debug!(
+							surface_id = ?surface.id(),
+							"commit: removing from current"
+						);
+					}
 				},
 			}
 		}
@@ -452,7 +458,7 @@ impl Dispatch<wp_color_manager_v1::WpColorManagerV1, ()> for MoonshineCompositor
 		_dhandle: &DisplayHandle,
 		data_init: &mut DataInit<'_, Self>,
 	) {
-		tracing::debug!(?request, "wp_color_manager_v1 request");
+		tracing::trace!(?request, "wp_color_manager_v1 request");
 		match request {
 			wp_color_manager_v1::Request::Destroy => {},
 
@@ -523,7 +529,7 @@ impl Dispatch<wp_color_management_surface_v1::WpColorManagementSurfaceV1, ColorS
 				render_intent: _,
 			} => {
 				if let Some(desc_data) = image_description.data::<ImageDescriptionUserData>() {
-					tracing::debug!(
+					tracing::trace!(
 						?desc_data.desc,
 						"Surface set image description"
 					);
@@ -573,7 +579,7 @@ impl Dispatch<wp_image_description_creator_params_v1::WpImageDescriptionCreatorP
 					mastering_primaries: params.mastering_primaries,
 					white_point: params.white_point,
 				};
-				tracing::debug!(?desc, "Created parametric image description");
+				tracing::trace!(?desc, "Created parametric image description");
 
 				let resource = data_init.init(image_description, ImageDescriptionUserData { desc });
 				// Signal that the image description is ready.
@@ -583,7 +589,10 @@ impl Dispatch<wp_image_description_creator_params_v1::WpImageDescriptionCreatorP
 			wp_image_description_creator_params_v1::Request::SetTfNamed { tf } => {
 				let tf = match tf.into_result() {
 					Ok(wp_color_manager_v1::TransferFunction::St2084Pq) => TransferFunction::St2084Pq,
-					Ok(wp_color_manager_v1::TransferFunction::Gamma22) => TransferFunction::Gamma22,
+					// sRGB's piecewise EOTF is close enough to pure gamma 2.2
+					// for SDR passthrough; both named TFs are advertised.
+					Ok(wp_color_manager_v1::TransferFunction::Gamma22)
+					| Ok(wp_color_manager_v1::TransferFunction::Srgb) => TransferFunction::Gamma22,
 					other => {
 						tracing::debug!(?other, "Unsupported transfer function, defaulting to gamma22");
 						TransferFunction::Gamma22

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -277,14 +277,22 @@ impl ColorManagementState {
 
 	/// Get the frame color space for the current fullscreen surface.
 	///
-	/// Returns the first non-sRGB color space declared by any mapped surface
-	/// (BT.2020+PQ or scRGB-linear), otherwise `Srgb`. Gamescope swapchain
-	/// declarations are checked first (higher priority), then wp_color_management
-	/// declarations.
+	/// When multiple HDR surfaces are declared, already-encoded BT.2020+PQ is
+	/// preferred over scRGB-linear: it is a passthrough path, whereas scRGB
+	/// requires a gamut+PQ conversion, so picking PQ avoids an unnecessary
+	/// conversion when both are present. Falls back to `Srgb` when no surface
+	/// declares an HDR color space. Gamescope swapchain declarations are checked
+	/// before wp_color_management declarations within each pass.
 	pub fn frame_color_space(&self) -> FrameColorSpace {
-		self.gamescope_current
-			.values()
-			.chain(self.current.values())
+		let color_spaces = || self.gamescope_current.values().chain(self.current.values());
+
+		// First pass: prefer already-encoded BT.2020+PQ (passthrough).
+		if color_spaces().any(|desc| desc.to_frame_color_space() == FrameColorSpace::Bt2020Pq) {
+			return FrameColorSpace::Bt2020Pq;
+		}
+
+		// Second pass: fall back to scRGB-linear, then sRGB.
+		color_spaces()
 			.map(|desc| desc.to_frame_color_space())
 			.find(|cs| *cs != FrameColorSpace::Srgb)
 			.unwrap_or(FrameColorSpace::Srgb)

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -93,7 +93,6 @@ impl ImageDescription {
 		}
 	}
 
-	#[cfg(test)]
 	pub fn scrgb_linear() -> Self {
 		Self {
 			transfer_function: TransferFunction::ScrgbLinear,
@@ -448,12 +447,14 @@ impl Dispatch<wp_color_manager_v1::WpColorManagerV1, ()> for MoonshineCompositor
 			},
 
 			wp_color_manager_v1::Request::CreateWindowsScrgb { image_description } => {
-				// Windows scRGB officially means BT.709 primaries + extended linear,
-				// but Proton/DXVK's gamescope WSI layer converts the scRGB surface data
-				// to BT.2020+PQ before submitting the buffer. We therefore map it to
-				// Bt2020Pq so the encoder treats the content as passthrough HDR rather
-				// than applying an unnecessary sRGB→BT.2020+PQ conversion.
-				let desc = ImageDescription::bt2020_pq();
+				// Windows scRGB is linear light with sRGB/BT.709 primaries (values
+				// > 1.0 for HDR highlights). Tag it scRGB-linear so the encoder
+				// applies the BT.709→BT.2020 gamut mapping + PQ OETF. DXVK content
+				// never arrives here: Mesa's Vulkan WSI expresses scRGB as a
+				// parametric ext_linear description (which we don't advertise, so
+				// DXVK falls back to an HDR10 swapchain and pre-converts). Only
+				// clients implementing windows_scrgb directly (e.g. mpv) use this.
+				let desc = ImageDescription::scrgb_linear();
 				let resource = data_init.init(image_description, ImageDescriptionUserData { desc });
 				resource.ready(0);
 			},

--- a/moonshine-core/src/session/compositor/color_management.rs
+++ b/moonshine-core/src/session/compositor/color_management.rs
@@ -93,6 +93,19 @@ impl ImageDescription {
 		}
 	}
 
+	#[cfg(test)]
+	pub fn scrgb_linear() -> Self {
+		Self {
+			transfer_function: TransferFunction::ScrgbLinear,
+			primaries: Primaries::Srgb,
+			max_cll: None,
+			max_fall: None,
+			mastering_luminance: None,
+			mastering_primaries: None,
+			white_point: None,
+		}
+	}
+
 	pub fn to_frame_color_space(self) -> FrameColorSpace {
 		match (self.primaries, self.transfer_function) {
 			(Primaries::Bt2020, TransferFunction::St2084Pq) => FrameColorSpace::Bt2020Pq,
@@ -890,5 +903,49 @@ impl Dispatch<wp_color_representation_surface_v1::WpColorRepresentationSurfaceV1
 
 			_ => {},
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{FrameColorSpace, ImageDescription, Primaries, TransferFunction};
+
+	#[test]
+	fn srgb_helper_maps_to_srgb_frame_color_space() {
+		assert_eq!(ImageDescription::srgb().to_frame_color_space(), FrameColorSpace::Srgb);
+	}
+
+	#[test]
+	fn bt2020_pq_helper_maps_to_bt2020pq_frame_color_space() {
+		let desc = ImageDescription::bt2020_pq();
+		assert_eq!(desc.primaries, Primaries::Bt2020);
+		assert_eq!(desc.transfer_function, TransferFunction::St2084Pq);
+		assert_eq!(desc.to_frame_color_space(), FrameColorSpace::Bt2020Pq);
+	}
+
+	#[test]
+	fn scrgb_linear_helper_maps_to_scrgb_frame_color_space() {
+		let desc = ImageDescription::scrgb_linear();
+		// scRGB uses BT.709 primaries, which share values with sRGB.
+		assert_eq!(desc.primaries, Primaries::Srgb);
+		assert_eq!(desc.transfer_function, TransferFunction::ScrgbLinear);
+		assert_eq!(desc.to_frame_color_space(), FrameColorSpace::ScrgbLinear);
+	}
+
+	#[test]
+	fn unrecognized_color_combination_falls_back_to_sdr() {
+		// Gamma22 with BT.2020 primaries is nonsensical; the fallback arm must
+		// route such descriptors to Srgb so SDR behaviour is preserved rather
+		// than misclassifying them as HDR.
+		let desc = ImageDescription {
+			primaries: Primaries::Bt2020,
+			transfer_function: TransferFunction::Gamma22,
+			max_cll: None,
+			max_fall: None,
+			mastering_luminance: None,
+			mastering_primaries: None,
+			white_point: None,
+		};
+		assert_eq!(desc.to_frame_color_space(), FrameColorSpace::Srgb);
 	}
 }

--- a/moonshine-core/src/session/compositor/frame.rs
+++ b/moonshine-core/src/session/compositor/frame.rs
@@ -26,7 +26,7 @@ pub(crate) enum FrameColorSpace {
 	/// `VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT`. The encoder must apply a
 	/// BT.709→BT.2020 gamut mapping and PQ OETF before YUV conversion (it is
 	/// *not* a passthrough), so it is tracked separately from `Bt2020Pq`.
-	Bt709Linear,
+	ScrgbLinear,
 }
 
 /// Static HDR metadata (HDR10).

--- a/moonshine-core/src/session/compositor/frame.rs
+++ b/moonshine-core/src/session/compositor/frame.rs
@@ -15,7 +15,18 @@ pub(crate) enum FrameColorSpace {
 	#[default]
 	Srgb,
 	/// HDR10 (BT.2020 primaries, PQ EOTF, BT.2020 NCL matrix).
+	///
+	/// The pixel data is already BT.2020+PQ encoded; the encoder converts it
+	/// straight to YUV (passthrough).
 	Bt2020Pq,
+	/// scRGB (BT.709 primaries, linear light, typically FP16 with values > 1.0
+	/// for HDR highlights).
+	///
+	/// Used by DXGI HDR games whose swapchain negotiates
+	/// `VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT`. The encoder must apply a
+	/// BT.709→BT.2020 gamut mapping and PQ OETF before YUV conversion (it is
+	/// *not* a passthrough), so it is tracked separately from `Bt2020Pq`.
+	Bt709Linear,
 }
 
 /// Static HDR metadata (HDR10).

--- a/moonshine-core/src/session/compositor/gamescope_swapchain.rs
+++ b/moonshine-core/src/session/compositor/gamescope_swapchain.rs
@@ -64,12 +64,11 @@ fn handle_swapchain_feedback(
 				cm.set_gamescope_colorspace(surface, TransferFunction::St2084Pq, Primaries::Bt2020);
 			},
 			// scRGB (extended sRGB, fp16): used by DXGI HDR games such as Control.
-			// Unlike the wp_color_manager `create_windows_scrgb` path (where DXVK
-			// pre-converts to BT.2020+PQ), the buffers arriving via gamescope swapchain
-			// feedback are still linear BT.709 with values > 1.0 for HDR highlights.
-			// Tag them as scRGB-linear so the encoder applies the BT.709→BT.2020 gamut
-			// mapping + PQ OETF instead of treating them as already-encoded BT.2020+PQ
-			// (which over-saturates and crushes highlights).
+			// The buffers arriving via gamescope swapchain feedback are linear
+			// BT.709 with values > 1.0 for HDR highlights. Tag them as scRGB-linear
+			// so the encoder applies the BT.709→BT.2020 gamut mapping + PQ OETF
+			// instead of treating them as already-encoded BT.2020+PQ (which
+			// over-saturates and crushes highlights).
 			VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT | VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT => {
 				tracing::info!("swapchain_feedback: extended sRGB (scRGB) detected, activating HDR");
 				cm.set_gamescope_colorspace(surface, TransferFunction::ScrgbLinear, Primaries::Srgb);

--- a/moonshine-core/src/session/compositor/gamescope_swapchain.rs
+++ b/moonshine-core/src/session/compositor/gamescope_swapchain.rs
@@ -72,7 +72,7 @@ fn handle_swapchain_feedback(
 			// (which over-saturates and crushes highlights).
 			VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT | VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT => {
 				tracing::info!("swapchain_feedback: extended sRGB (scRGB) detected, activating HDR");
-				cm.set_gamescope_colorspace(surface, TransferFunction::LinearExtended, Primaries::Srgb);
+				cm.set_gamescope_colorspace(surface, TransferFunction::ScrgbLinear, Primaries::Srgb);
 			},
 			VK_COLOR_SPACE_SRGB_NONLINEAR => {
 				cm.clear_gamescope_current(surface);

--- a/moonshine-core/src/session/compositor/gamescope_swapchain.rs
+++ b/moonshine-core/src/session/compositor/gamescope_swapchain.rs
@@ -50,24 +50,29 @@ fn handle_swapchain_feedback(
 	// Some games (e.g. Monster Hunter Wilds) never call vkSetHdrMetadataEXT
 	// and rely solely on the swapchain color space to signal HDR.
 	const VK_COLOR_SPACE_SRGB_NONLINEAR: u32 = 0;
+	const VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT: u32 = 1000104002;
 	const VK_COLOR_SPACE_HDR10_ST2084_EXT: u32 = 1000104008;
+	const VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT: u32 = 1000104014;
 
 	if let Some(cm) = &mut state.color_management {
 		match vk_colorspace {
+			// HDR10: the game submits BT.2020 + PQ data directly.
+			// Use `set_gamescope_colorspace` (not `set_gamescope_current`) so that
+			// mastering metadata from a prior `vkSetHdrMetadataEXT` is preserved.
 			VK_COLOR_SPACE_HDR10_ST2084_EXT => {
 				tracing::info!("swapchain_feedback: HDR10_ST2084 detected, activating HDR");
-				cm.set_gamescope_current(
-					surface,
-					super::color_management::ImageDescription {
-						transfer_function: super::color_management::TransferFunction::St2084Pq,
-						primaries: super::color_management::Primaries::Bt2020,
-						max_cll: None,
-						max_fall: None,
-						mastering_luminance: None,
-						mastering_primaries: None,
-						white_point: None,
-					},
-				);
+				cm.set_gamescope_colorspace(surface, TransferFunction::St2084Pq, Primaries::Bt2020);
+			},
+			// scRGB (extended sRGB, fp16): used by DXGI HDR games such as Control.
+			// Unlike the wp_color_manager `create_windows_scrgb` path (where DXVK
+			// pre-converts to BT.2020+PQ), the buffers arriving via gamescope swapchain
+			// feedback are still linear BT.709 with values > 1.0 for HDR highlights.
+			// Tag them as scRGB-linear so the encoder applies the BT.709→BT.2020 gamut
+			// mapping + PQ OETF instead of treating them as already-encoded BT.2020+PQ
+			// (which over-saturates and crushes highlights).
+			VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT | VK_COLOR_SPACE_EXTENDED_SRGB_NONLINEAR_EXT => {
+				tracing::info!("swapchain_feedback: extended sRGB (scRGB) detected, activating HDR");
+				cm.set_gamescope_colorspace(surface, TransferFunction::LinearExtended, Primaries::Srgb);
 			},
 			VK_COLOR_SPACE_SRGB_NONLINEAR => {
 				cm.clear_gamescope_current(surface);

--- a/moonshine-core/src/session/compositor/gamescope_swapchain.rs
+++ b/moonshine-core/src/session/compositor/gamescope_swapchain.rs
@@ -12,7 +12,7 @@
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource};
 
-use crate::session::compositor::color_management::{ImageDescription, Primaries, TransferFunction};
+use crate::session::compositor::color_management::{Primaries, TransferFunction};
 use crate::session::compositor::protocols::gamescope_swapchain::GamescopeSwapchain;
 use crate::session::compositor::protocols::gamescope_swapchain_factory_v2::GamescopeSwapchainFactoryV2;
 use crate::session::compositor::protocols::moonshine_swapchain::MoonshineSwapchain;
@@ -57,8 +57,8 @@ fn handle_swapchain_feedback(
 	if let Some(cm) = &mut state.color_management {
 		match vk_colorspace {
 			// HDR10: the game submits BT.2020 + PQ data directly.
-			// Use `set_gamescope_colorspace` (not `set_gamescope_current`) so that
-			// mastering metadata from a prior `vkSetHdrMetadataEXT` is preserved.
+			// `set_gamescope_colorspace` preserves mastering metadata from a
+			// prior `vkSetHdrMetadataEXT`.
 			VK_COLOR_SPACE_HDR10_ST2084_EXT => {
 				tracing::info!("swapchain_feedback: HDR10_ST2084 detected, activating HDR");
 				cm.set_gamescope_colorspace(surface, TransferFunction::St2084Pq, Primaries::Bt2020);
@@ -124,29 +124,32 @@ fn handle_set_hdr_metadata(
 		"set_hdr_metadata"
 	);
 
-	// The WSI layer remaps HDR→sRGB for the ICD, but DXVK doesn't see the
-	// remap and performs sRGB→PQ conversion in its swapchain blitter.  The
-	// pixel data arriving at the compositor is genuinely PQ-encoded, so we
-	// set Bt2020Pq here.
+	// `vkSetHdrMetadataEXT` carries only mastering metadata; the transfer
+	// function comes from the swapchain color space. Update just the metadata,
+	// preserving a colorspace already established by `swapchain_feedback` —
+	// e.g. Cyberpunk sets HDR metadata *after* its scRGB swapchain is created,
+	// and overwriting the description here would mislabel the linear scRGB
+	// buffers as PQ-encoded. When no colorspace was declared yet this defaults
+	// to BT.2020+PQ: the WSI layer remaps HDR→sRGB for the ICD, but DXVK
+	// doesn't see the remap and performs sRGB→PQ conversion in its swapchain
+	// blitter, so the pixel data arriving at the compositor is PQ-encoded.
 	if let Some(cm) = &mut state.color_management {
-		let desc = ImageDescription {
-			transfer_function: TransferFunction::St2084Pq,
-			primaries: Primaries::Bt2020,
-			max_cll: Some(max_cll),
-			max_fall: Some(max_fall),
+		cm.set_gamescope_hdr_metadata(
+			surface,
+			max_cll,
+			max_fall,
 			// max is in 1 cd/m², min is in 0.0001 cd/m²; normalize both to 0.0001 cd/m² units.
-			mastering_luminance: Some((
+			(
 				min_display_mastering_luminance,
 				max_display_mastering_luminance.saturating_mul(10000),
-			)),
-			mastering_primaries: Some([
+			),
+			[
 				(display_primary_red_x, display_primary_red_y),
 				(display_primary_green_x, display_primary_green_y),
 				(display_primary_blue_x, display_primary_blue_y),
-			]),
-			white_point: Some((white_point_x, white_point_y)),
-		};
-		cm.set_gamescope_current(surface, desc);
+			],
+			(white_point_x, white_point_y),
+		);
 	}
 }
 

--- a/moonshine-core/src/session/compositor/mod.rs
+++ b/moonshine-core/src/session/compositor/mod.rs
@@ -256,14 +256,17 @@ fn run_compositor(
 	tracing::debug!("Supported DMA-BUF render formats: {}", render_formats.iter().count());
 
 	// Select preferred render format based on HDR mode.
-	// HDR: prefer 10-bit > FP16 > 8-bit ABGR (to match common Vulkan WSI format).
+	// HDR: prefer FP16 > 10-bit > 8-bit ABGR. FP16 is required for scRGB
+	// (EXTENDED_SRGB_LINEAR) content whose HDR highlights carry values > 1.0 that a
+	// 10-bit UNORM render buffer would clamp at composite time; it also holds
+	// BT.2020+PQ content (values in [0,1]) losslessly for the passthrough path.
 	// SDR: prefer 8-bit ABGR/XBGR to match Vulkan WSI and avoid GL R↔B channel swaps.
 	// Vulkan WSI on Wayland defaults to XBGR/ABGR formats, so using ARGB causes
 	// GL to incorrectly swap red/blue channels during blit operations.
 	let preferred_fourccs: Vec<Fourcc> = if config.hdr && context.hdr {
 		vec![
-			Fourcc::Abgr2101010,
 			Fourcc::Abgr16161616f,
+			Fourcc::Abgr2101010,
 			Fourcc::Abgr8888,
 			Fourcc::Xbgr8888,
 		]

--- a/moonshine-core/src/session/compositor/state.rs
+++ b/moonshine-core/src/session/compositor/state.rs
@@ -390,6 +390,11 @@ pub(crate) struct MoonshineCompositor {
 		std::collections::HashMap<smithay::reexports::wayland_server::backend::ObjectId, usize>,
 	/// Next available scanout buffer index.
 	scanout_next_index: usize,
+	/// Last logged direct-scanout buffer parameters (fourcc, modifier,
+	/// num_planes, width, height). NVIDIA's Wayland WSI wraps a new
+	/// `wl_buffer` (and thus a new buffer index) every frame, so imports are
+	/// only logged when these parameters change rather than per buffer.
+	last_scanout_buffer_desc: Option<(u32, u64, usize, u32, u32)>,
 }
 
 /// Client state required by Smithay's compositor.
@@ -620,6 +625,7 @@ impl MoonshineCompositor {
 				held_scanout_buffers: Vec::new(),
 				scanout_buffer_map: std::collections::HashMap::new(),
 				scanout_next_index: BUFFER_POOL_SIZE,
+				last_scanout_buffer_desc: None,
 			},
 			display,
 		)
@@ -1161,17 +1167,31 @@ impl MoonshineCompositor {
 		let buffer_index = *self.scanout_buffer_map.entry(buffer_id.clone()).or_insert_with(|| {
 			let idx = self.scanout_next_index;
 			self.scanout_next_index += 1;
+			idx
+		});
+
+		// Log buffer parameters only when they change — logging every new
+		// buffer index would spam at frame rate on NVIDIA (see
+		// `last_scanout_buffer_desc`).
+		let buffer_desc = (
+			client_dmabuf.format().code as u32,
+			Into::<u64>::into(client_dmabuf.format().modifier),
+			client_dmabuf.num_planes(),
+			client_dmabuf.width(),
+			client_dmabuf.height(),
+		);
+		if self.last_scanout_buffer_desc != Some(buffer_desc) {
 			tracing::debug!(
-				buffer_index = self.scanout_next_index - 1,
+				buffer_index,
 				fourcc = ?client_dmabuf.format().code,
 				modifier = format!("{:#x}", Into::<u64>::into(client_dmabuf.format().modifier)).as_str(),
 				num_planes = client_dmabuf.num_planes(),
 				width = client_dmabuf.width(),
 				height = client_dmabuf.height(),
-				"Override scanout: importing new buffer",
+				"Override scanout: buffer parameters changed",
 			);
-			idx
-		});
+			self.last_scanout_buffer_desc = Some(buffer_desc);
+		}
 
 		let consumed = Arc::new(AtomicBool::new(false));
 

--- a/moonshine-core/src/session/stream/video/pipeline/dmabuf.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/dmabuf.rs
@@ -14,6 +14,13 @@
 //! underlying DMA-BUF fd is stable. ObjectId-keying would miss the cache
 //! every frame; FD-keying catches the reuse.
 //!
+//! The kernel also recycles fd numbers for *new* buffers (e.g. when a game
+//! recreates its swapchain after switching HDR format from PQ to scRGB), so a
+//! cache hit on the fd alone may actually be a different buffer. A hit is only
+//! trusted when the import parameters (dimensions, format, plane layout,
+//! modifier) also match; mismatched entries are retired and freed after
+//! `CACHE_TTL`, once any in-flight GPU work using them has completed.
+//!
 //! The cache evicts entries that have not been touched in `CACHE_TTL`. The
 //! compositor holds client buffers alive until the encoder signals `consumed`,
 //! so the fd is guaranteed valid during import. The 2s TTL ensures any
@@ -51,10 +58,42 @@ pub(crate) struct DmaBufPlane {
 	pub modifier: u64,
 }
 
+/// Identifying parameters of a DMA-BUF import. A cached image may only be
+/// reused when all of these match the new request; a mismatch on the same fd
+/// means the fd number was recycled for a different buffer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ImportParams {
+	width: u32,
+	height: u32,
+	format: vk::Format,
+	modifier: u64,
+	plane_count: usize,
+	/// (offset, stride) per plane.
+	plane_layouts: [(u32, u32); 4],
+}
+
+impl ImportParams {
+	fn new(width: u32, height: u32, format: vk::Format, planes: &[DmaBufPlane]) -> Self {
+		let mut plane_layouts = [(0, 0); 4];
+		for (i, p) in planes.iter().take(4).enumerate() {
+			plane_layouts[i] = (p.offset, p.stride);
+		}
+		Self {
+			width,
+			height,
+			format,
+			modifier: planes.first().map_or(0, |p| p.modifier),
+			plane_count: planes.len().min(4),
+			plane_layouts,
+		}
+	}
+}
+
 /// Cached Vulkan resources for a single compositor buffer slot.
 struct CachedImport {
 	image: vk::Image,
 	memory: vk::DeviceMemory,
+	params: ImportParams,
 	last_used: Instant,
 }
 
@@ -69,6 +108,9 @@ pub(crate) struct DmaBufImporter {
 	/// Per-FD cache — keyed by the DMA-BUF fd so the same underlying buffer
 	/// is reused even when the driver wraps it in new `wl_buffer` objects.
 	cache: HashMap<RawFd, CachedImport>,
+	/// Imports whose fd was recycled for a different buffer, awaiting TTL
+	/// expiry before destruction (in-flight GPU work may still reference them).
+	retired: Vec<CachedImport>,
 	/// Calls since the last stale-entry sweep.
 	calls_since_sweep: u32,
 }
@@ -82,12 +124,13 @@ impl DmaBufImporter {
 			context,
 			external_memory_fd,
 			cache: HashMap::new(),
+			retired: Vec::new(),
 			calls_since_sweep: 0,
 		})
 	}
 
 	/// Import a DMA-BUF as a Vulkan image, reusing a cached import when
-	/// the same DMA-BUF fd has been seen before.
+	/// the same DMA-BUF fd has been seen before with the same parameters.
 	///
 	/// The `format` parameter specifies the Vulkan format matching the DMA-BUF
 	/// pixel format (e.g. `B8G8R8A8_UNORM` for SDR, `A2B10G10R10_UNORM_PACK32`
@@ -111,10 +154,28 @@ impl DmaBufImporter {
 			self.evict_stale();
 		}
 
+		let params = ImportParams::new(width, height, format, planes);
+
 		let now = Instant::now();
 		if let Some(cached) = self.cache.get_mut(&fd) {
-			cached.last_used = now;
-			return Ok((cached.image, false));
+			if cached.params == params {
+				cached.last_used = now;
+				return Ok((cached.image, false));
+			}
+		}
+
+		// A leftover entry here means the fd number was recycled for a
+		// different buffer (e.g. a swapchain recreation when the game switches
+		// HDR format). Reusing the stale image would make the GPU read the old
+		// buffer with the wrong format/stride — a device-lost fault. Retire it
+		// for TTL-deferred destruction in case prior GPU work still uses it.
+		if let Some(mut stale) = self.cache.remove(&fd) {
+			debug!(
+				"fd {fd} now refers to a different buffer ({:?} -> {:?}); retiring stale import",
+				stale.params, params
+			);
+			stale.last_used = now;
+			self.retired.push(stale);
 		}
 
 		// First time seeing this DMA-BUF — full import.
@@ -130,6 +191,7 @@ impl DmaBufImporter {
 			CachedImport {
 				image,
 				memory,
+				params,
 				last_used: now,
 			},
 		);
@@ -143,8 +205,7 @@ impl DmaBufImporter {
 	fn evict_stale(&mut self) {
 		let cutoff = Instant::now() - CACHE_TTL;
 		let device = self.context.device();
-		let before = self.cache.len();
-		self.cache.retain(|_, v| {
+		let destroy_if_expired = |v: &CachedImport| {
 			if v.last_used < cutoff {
 				unsafe {
 					device.destroy_image(v.image, None);
@@ -154,8 +215,11 @@ impl DmaBufImporter {
 			} else {
 				true
 			}
-		});
-		let evicted = before - self.cache.len();
+		};
+		let before = self.cache.len() + self.retired.len();
+		self.cache.retain(|_, v| destroy_if_expired(v));
+		self.retired.retain(destroy_if_expired);
+		let evicted = before - self.cache.len() - self.retired.len();
 		if evicted > 0 {
 			trace!(
 				"DmaBufImporter: evicted {evicted} stale cache entries, {} live",
@@ -292,10 +356,49 @@ impl Drop for DmaBufImporter {
 	fn drop(&mut self) {
 		let device = self.context.device();
 		unsafe {
-			for (_, cached) in self.cache.drain() {
+			for cached in self.cache.drain().map(|(_, v)| v).chain(self.retired.drain(..)) {
 				device.destroy_image(cached.image, None);
 				device.free_memory(cached.memory, None);
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{DmaBufPlane, ImportParams};
+	use ash::vk;
+
+	fn plane(offset: u32, stride: u32) -> DmaBufPlane {
+		DmaBufPlane {
+			fd: 42,
+			offset,
+			stride,
+			modifier: 0xdead,
+		}
+	}
+
+	#[test]
+	fn import_params_match_for_identical_buffer() {
+		let a = ImportParams::new(1920, 1080, vk::Format::A2B10G10R10_UNORM_PACK32, &[plane(0, 7680)]);
+		let b = ImportParams::new(1920, 1080, vk::Format::A2B10G10R10_UNORM_PACK32, &[plane(0, 7680)]);
+		assert_eq!(a, b);
+	}
+
+	#[test]
+	fn import_params_detect_recycled_fd_after_format_switch() {
+		// PQ→scRGB swapchain recreation: the new FP16 buffer can land on the
+		// same fd number as the destroyed 10-bit buffer, with a different
+		// format and stride. The cache must not treat this as a hit.
+		let pq = ImportParams::new(1920, 1080, vk::Format::A2B10G10R10_UNORM_PACK32, &[plane(0, 7680)]);
+		let scrgb = ImportParams::new(1920, 1080, vk::Format::R16G16B16A16_SFLOAT, &[plane(0, 15360)]);
+		assert_ne!(pq, scrgb);
+	}
+
+	#[test]
+	fn import_params_detect_stride_only_change() {
+		let a = ImportParams::new(1920, 1080, vk::Format::R16G16B16A16_SFLOAT, &[plane(0, 15360)]);
+		let b = ImportParams::new(1920, 1080, vk::Format::R16G16B16A16_SFLOAT, &[plane(0, 16384)]);
+		assert_ne!(a, b);
 	}
 }

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -516,7 +516,7 @@ impl VideoPipelineInner {
 					let (cs, full_range, color_desc, sdr_white_nits) = match frame_cs {
 						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709(), 203.0),
 						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq(), 203.0),
-						FrameColorSpace::Bt709Linear => (
+						FrameColorSpace::ScrgbLinear => (
 							ColorSpace::Bt709LinearToBt2020Pq,
 							false,
 							ColorDescription::bt2020_pq(),

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -30,6 +30,11 @@ use pixelforge::{
 	InputFormat, OutputFormat, PixelFormat, RateControlMode, VideoContext, VideoContextBuilder,
 };
 
+/// scRGB reference white: linear value 1.0 maps to 80 cd/m² (IEC 61966-2-2).
+const SCRGB_REFERENCE_WHITE_NITS: f32 = 80.0;
+/// SDR reference white for HDR transport, per ITU-R BT.2408 (203 cd/m²).
+const BT2408_SDR_REFERENCE_NITS: f32 = 203.0;
+
 /// Map a DRM fourcc format code to the corresponding pixelforge InputFormat
 /// and Vulkan import format.
 fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
@@ -514,13 +519,23 @@ impl VideoPipelineInner {
 					// `sdr_white_nits` only matters for the scRGB path: per IEC 61966-2-2,
 					// scRGB 1.0 == 80 cd/m². The other paths ignore it.
 					let (cs, full_range, color_desc, sdr_white_nits) = match frame_cs {
-						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709(), 203.0),
-						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq(), 203.0),
+						FrameColorSpace::Srgb => (
+							ColorSpace::Bt709,
+							true,
+							ColorDescription::bt709(),
+							BT2408_SDR_REFERENCE_NITS,
+						),
+						FrameColorSpace::Bt2020Pq => (
+							ColorSpace::Bt2020,
+							false,
+							ColorDescription::bt2020_pq(),
+							BT2408_SDR_REFERENCE_NITS,
+						),
 						FrameColorSpace::ScrgbLinear => (
 							ColorSpace::Bt709LinearToBt2020Pq,
 							false,
 							ColorDescription::bt2020_pq(),
-							80.0,
+							SCRGB_REFERENCE_WHITE_NITS,
 						),
 					};
 

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -804,3 +804,70 @@ impl VideoPipelineInner {
 		Ok((t_packetized - t_start, t_sent - t_packetized))
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::{drm_fourcc_to_input, BT2408_SDR_REFERENCE_NITS, SCRGB_REFERENCE_WHITE_NITS};
+	use ash::vk;
+	use pixelforge::InputFormat;
+
+	// DRM fourccs — kept in the test module to document the byte ordering
+	// explicitly and guard against accidental typos in the production match.
+	// Layout: fourcc_code(a, b, c, d) = a | b<<8 | c<<16 | d<<24.
+	const ABGR8888: u32 = 0x34324241; // "AB24"
+	const XBGR8888: u32 = 0x34324258; // "XB24"
+	const ABGR2101010: u32 = 0x30334241; // "AB30"
+	const XBGR2101010: u32 = 0x30334258; // "XB30"
+	const ABGR16161616F: u32 = 0x48344241; // "AB4H"
+	const XBGR16161616F: u32 = 0x48344258; // "XB4H"
+
+	#[test]
+	fn drm_fourcc_abgr_xbgr_8bit_maps_to_rgba() {
+		// 8-bit ABGR/XBGR share the same bit layout (alpha vs. padding) and
+		// map to R8G8B8A8_UNORM.
+		for fourcc in [ABGR8888, XBGR8888] {
+			let (fmt, vk) = drm_fourcc_to_input(fourcc);
+			assert_eq!(fmt, InputFormat::RGBA);
+			assert_eq!(vk, vk::Format::R8G8B8A8_UNORM);
+		}
+	}
+
+	#[test]
+	fn drm_fourcc_abgr_xbgr_10bit_maps_to_a2b10g10r10() {
+		for fourcc in [ABGR2101010, XBGR2101010] {
+			let (fmt, vk) = drm_fourcc_to_input(fourcc);
+			assert_eq!(fmt, InputFormat::ABGR2101010);
+			assert_eq!(vk, vk::Format::A2B10G10R10_UNORM_PACK32);
+		}
+	}
+
+	#[test]
+	fn drm_fourcc_abgr_xbgr_fp16_maps_to_rgba16f() {
+		// Regression guard for the XBGR16161616F (XB4H) case: NVIDIA's Wayland
+		// WSI emits the X-variant for FP16 scRGB swapchains, and handling only
+		// the A-variant caused 16F buffers to fall through to the 8-bit BGRx
+		// fallback and produce garbled pixels.
+		for fourcc in [ABGR16161616F, XBGR16161616F] {
+			let (fmt, vk) = drm_fourcc_to_input(fourcc);
+			assert_eq!(fmt, InputFormat::RGBA16F);
+			assert_eq!(vk, vk::Format::R16G16B16A16_SFLOAT);
+		}
+	}
+
+	#[test]
+	fn drm_fourcc_unknown_falls_back_to_bgrx() {
+		// Anything outside the known set must fall back to the 8-bit BGRx
+		// assumption — matches the `_ =>` arm in the production match.
+		let (fmt, vk) = drm_fourcc_to_input(0xDEADBEEF);
+		assert_eq!(fmt, InputFormat::BGRx);
+		assert_eq!(vk, vk::Format::B8G8R8A8_UNORM);
+	}
+
+	#[test]
+	fn sdr_reference_white_constants_match_specs() {
+		// scRGB (IEC 61966-2-2): 1.0 == 80 cd/m².
+		assert_eq!(SCRGB_REFERENCE_WHITE_NITS, 80.0);
+		// ITU-R BT.2408: 203 cd/m² diffuse white for SDR-in-HDR.
+		assert_eq!(BT2408_SDR_REFERENCE_NITS, 203.0);
+	}
+}

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -27,7 +27,7 @@ use dmabuf::{DmaBufImporter, DmaBufPlane};
 
 use pixelforge::{
 	Codec, ColorConverter, ColorConverterConfig, ColorDescription, ColorSpace, EncodeConfig, EncodedPacket, Encoder,
-	InputFormat, OutputFormat, PixelFormat, RateControlMode, VideoContext, VideoContextBuilder,
+	InputFormat, OutputFormat, PixelForgeError, PixelFormat, RateControlMode, VideoContext, VideoContextBuilder,
 };
 
 /// scRGB reference white: linear value 1.0 maps to 80 cd/m² (IEC 61966-2-2).
@@ -57,6 +57,21 @@ fn drm_fourcc_to_input(fourcc: u32) -> (InputFormat, vk::Format) {
 		},
 		0x48344241 | 0x48344258 => (InputFormat::RGBA16F, vk::Format::R16G16B16A16_SFLOAT), // ABGR/XBGR16161616F
 		_ => (InputFormat::BGRx, vk::Format::B8G8R8A8_UNORM),                               // ARGB/XRGB8888 (fallback)
+	}
+}
+
+/// Whether a pixelforge error indicates Vulkan device loss.
+///
+/// Device loss is unrecoverable on the existing device: every subsequent GPU
+/// operation fails the same way, so the encoding loop must exit (shutting the
+/// session down) instead of retrying forever and freezing the stream.
+fn is_device_lost(e: &PixelForgeError) -> bool {
+	match e {
+		PixelForgeError::Vulkan(result) => *result == vk::Result::ERROR_DEVICE_LOST,
+		// Other variants (e.g. CommandBuffer) stringify the underlying
+		// vk::Result, whose ash display text is "The logical device has been
+		// lost. See <...>".
+		_ => e.to_string().contains("device has been lost"),
 	}
 }
 
@@ -564,8 +579,11 @@ impl VideoPipelineInner {
 
 				// Convert to YUV.
 				if let Err(e) = converter.convert(source_image, src_layout, encoder.input_image()) {
-					tracing::warn!("GPU color conversion failed: {e}");
 					frame.consumed.store(true, Ordering::Release);
+					if is_device_lost(&e) {
+						return Err(format!("GPU color conversion failed: {e}"));
+					}
+					tracing::warn!("GPU color conversion failed: {e}");
 					continue;
 				}
 
@@ -646,6 +664,9 @@ impl VideoPipelineInner {
 						}
 					},
 					Err(e) => {
+						if is_device_lost(&e) {
+							return Err(format!("Failed to encode frame: {e}"));
+						}
 						tracing::warn!("Failed to encode frame: {e}");
 					},
 				}
@@ -807,9 +828,9 @@ impl VideoPipelineInner {
 
 #[cfg(test)]
 mod tests {
-	use super::{drm_fourcc_to_input, BT2408_SDR_REFERENCE_NITS, SCRGB_REFERENCE_WHITE_NITS};
+	use super::{drm_fourcc_to_input, is_device_lost, BT2408_SDR_REFERENCE_NITS, SCRGB_REFERENCE_WHITE_NITS};
 	use ash::vk;
-	use pixelforge::InputFormat;
+	use pixelforge::{InputFormat, PixelForgeError};
 
 	// DRM fourccs — kept in the test module to document the byte ordering
 	// explicitly and guard against accidental typos in the production match.
@@ -861,6 +882,26 @@ mod tests {
 		let (fmt, vk) = drm_fourcc_to_input(0xDEADBEEF);
 		assert_eq!(fmt, InputFormat::BGRx);
 		assert_eq!(vk, vk::Format::B8G8R8A8_UNORM);
+	}
+
+	#[test]
+	fn device_lost_is_detected_in_both_error_shapes() {
+		// Structured variant.
+		assert!(is_device_lost(&PixelForgeError::Vulkan(vk::Result::ERROR_DEVICE_LOST)));
+		// String variant: pixelforge wraps the vk::Result display text, e.g.
+		// CommandBuffer("The logical device has been lost. See <...>") —
+		// the shape observed when a stale DMA-BUF import faults the GPU.
+		assert!(is_device_lost(&PixelForgeError::CommandBuffer(
+			vk::Result::ERROR_DEVICE_LOST.to_string()
+		)));
+	}
+
+	#[test]
+	fn recoverable_errors_are_not_device_lost() {
+		assert!(!is_device_lost(&PixelForgeError::Vulkan(vk::Result::TIMEOUT)));
+		assert!(!is_device_lost(&PixelForgeError::CommandBuffer(
+			"submit failed".to_string()
+		)));
 	}
 
 	#[test]

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -86,14 +86,23 @@ struct LatencySample {
 	packetize: std::time::Duration,
 	send: std::time::Duration,
 	total: std::time::Duration,
+	encoded_bytes: usize,
+	is_key_frame: bool,
 }
 
 /// Log a summary of latency statistics over a batch of samples.
-fn log_latency_summary(samples: &[LatencySample]) {
+///
+/// `elapsed` is the wall-clock time the batch was collected over, used to
+/// derive throughput (fps, bitrate).
+fn log_latency_summary(samples: &[LatencySample], elapsed: std::time::Duration) {
 	let n = samples.len();
 	if n == 0 {
 		return;
 	}
+
+	let elapsed_s = elapsed.as_secs_f64().max(f64::EPSILON);
+	let bytes_total: usize = samples.iter().map(|s| s.encoded_bytes).sum();
+	let keyframes = samples.iter().filter(|s| s.is_key_frame).count();
 
 	let mut totals: Vec<u64> = samples.iter().map(|s| s.total.as_micros() as u64).collect();
 	totals.sort_unstable();
@@ -122,6 +131,9 @@ fn log_latency_summary(samples: &[LatencySample]) {
 
 	tracing::debug!(
 		frames = n,
+		fps = (n as f64 / elapsed_s).round() as u32,
+		bitrate_kbps = ((bytes_total * 8) as f64 / elapsed_s / 1000.0).round() as u64,
+		keyframes,
 		total_p50_us = p50(&totals),
 		total_p95_us = p95(&totals),
 		total_p99_us = p99(&totals),
@@ -718,6 +730,8 @@ impl VideoPipelineInner {
 					packetize: packetize_dur,
 					send: send_dur,
 					total,
+					encoded_bytes,
+					is_key_frame,
 				});
 
 				let _ = stats_tx.send(FrameStats {
@@ -734,7 +748,7 @@ impl VideoPipelineInner {
 
 				// Periodic summary every 5 seconds.
 				if last_summary_time.elapsed() >= std::time::Duration::from_secs(5) && !latency_samples.is_empty() {
-					log_latency_summary(&latency_samples);
+					log_latency_summary(&latency_samples, last_summary_time.elapsed());
 					latency_samples.clear();
 					last_summary_time = std::time::Instant::now();
 				}

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -515,12 +515,13 @@ impl VideoPipelineInner {
 					// scRGB 1.0 == 80 cd/m². The other paths ignore it.
 					let (cs, full_range, color_desc, sdr_white_nits) = match frame_cs {
 						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709(), 203.0),
-						FrameColorSpace::Bt2020Pq => {
-							(ColorSpace::Bt2020, false, ColorDescription::bt2020_pq(), 203.0)
-						},
-						FrameColorSpace::Bt709Linear => {
-							(ColorSpace::Bt709LinearToBt2020Pq, false, ColorDescription::bt2020_pq(), 80.0)
-						},
+						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq(), 203.0),
+						FrameColorSpace::Bt709Linear => (
+							ColorSpace::Bt709LinearToBt2020Pq,
+							false,
+							ColorDescription::bt2020_pq(),
+							80.0,
+						),
 					};
 
 					// Switch encoder VUI first. Only update the converter if

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -13,7 +13,7 @@ use ash::vk;
 use async_shutdown::ShutdownManager;
 use tokio::sync::{broadcast, mpsc, watch, Notify};
 
-use crate::session::compositor::frame::{ExportedFrame, FrameColorSpace, HdrModeState};
+use crate::session::compositor::frame::{ExportedFrame, FrameColorSpace, HdrMetadata, HdrModeState};
 use crate::session::manager::SessionShutdownReason;
 use crate::session::SessionKeysReceiver;
 
@@ -511,9 +511,16 @@ impl VideoPipelineInner {
 				// dynamic VUI switching in the encoder.
 				if ctx.dynamic_range == VideoDynamicRange::Hdr {
 					let frame_cs = frame.color_space;
-					let (cs, full_range, color_desc) = match frame_cs {
-						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709()),
-						FrameColorSpace::Bt2020Pq => (ColorSpace::Bt2020, false, ColorDescription::bt2020_pq()),
+					// `sdr_white_nits` only matters for the scRGB path: per IEC 61966-2-2,
+					// scRGB 1.0 == 80 cd/m². The other paths ignore it.
+					let (cs, full_range, color_desc, sdr_white_nits) = match frame_cs {
+						FrameColorSpace::Srgb => (ColorSpace::Bt709, true, ColorDescription::bt709(), 203.0),
+						FrameColorSpace::Bt2020Pq => {
+							(ColorSpace::Bt2020, false, ColorDescription::bt2020_pq(), 203.0)
+						},
+						FrameColorSpace::Bt709Linear => {
+							(ColorSpace::Bt709LinearToBt2020Pq, false, ColorDescription::bt2020_pq(), 80.0)
+						},
 					};
 
 					// Switch encoder VUI first. Only update the converter if
@@ -528,12 +535,14 @@ impl VideoPipelineInner {
 								encoder_color_desc = Some(color_desc);
 								converter.set_color_space(cs);
 								converter.set_full_range(full_range);
+								converter.set_sdr_reference_white_nits(sdr_white_nits);
 							},
 							Err(e) => return Err(format!("Failed to update encoder color description: {e}")),
 						}
 					} else {
 						converter.set_color_space(cs);
 						converter.set_full_range(full_range);
+						converter.set_sdr_reference_white_nits(sdr_white_nits);
 					}
 				}
 
@@ -591,9 +600,12 @@ impl VideoPipelineInner {
 							// but only when encoding as BT.2020+PQ (HDR frames).
 							// SDR frames encoded as BT.709 should not carry HDR SEI.
 							if packet.is_key_frame && encoder_color_desc == Some(ColorDescription::bt2020_pq()) {
-								if let Some(ref m) = last_hdr_state.metadata {
-									packet.data = hdr_sei::inject_hdr_metadata(&packet.data, m, ctx.video_format);
-								}
+								// Fall back to default HDR10 metadata when the content provides
+								// none (e.g. scRGB swapchains carry no mastering metadata), so the
+								// bitstream stays consistent with the control-stream HDR metadata,
+								// which also falls back to `HdrMetadata::fallback`.
+								let m = last_hdr_state.metadata.unwrap_or_else(HdrMetadata::fallback);
+								packet.data = hdr_sei::inject_hdr_metadata(&packet.data, &m, ctx.video_format);
 							}
 
 							encoded_bytes += packet.data.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,28 +26,9 @@ struct Args {
 async fn main() -> Result<(), ()> {
 	let args = Args::parse();
 
-	// Some dependencies emit DEBUG logs at frame rate, drowning out
-	// moonshine's own debug output:
-	// - pixelforge: convert/encode timings and slice dumps per encoded frame
-	//   (the same timing data is aggregated by the video pipeline into a
-	//   5-second percentile summary);
-	// - smithay's GLES renderer: GL driver debug-callback messages ("Buffer
-	//   detailed info: ..." on NVIDIA) per rendered frame.
-	// Default those targets to `info` unless MOONSHINE_LOG configures them
-	// explicitly (e.g. `MOONSHINE_LOG=debug,pixelforge=debug`).
-	let mut log_filter = std::env::var("MOONSHINE_LOG").unwrap_or_else(|_| "error".to_string());
-	for (target, directive) in [
-		("pixelforge", "pixelforge=info"),
-		("smithay", "smithay::backend::renderer::gles=info"),
-	] {
-		if !log_filter.contains(target) {
-			log_filter.push(',');
-			log_filter.push_str(directive);
-		}
-	}
 	tracing_subscriber::registry()
 		.with(tracing_subscriber::fmt::layer())
-		.with(EnvFilter::try_new(&log_filter).unwrap_or_else(|_| EnvFilter::new("error")))
+		.with(EnvFilter::try_from_env("MOONSHINE_LOG").unwrap_or_else(|_| EnvFilter::new("error")))
 		.init();
 
 	let mut config = Config::load_or_create(&args.config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,9 +26,28 @@ struct Args {
 async fn main() -> Result<(), ()> {
 	let args = Args::parse();
 
+	// Some dependencies emit DEBUG logs at frame rate, drowning out
+	// moonshine's own debug output:
+	// - pixelforge: convert/encode timings and slice dumps per encoded frame
+	//   (the same timing data is aggregated by the video pipeline into a
+	//   5-second percentile summary);
+	// - smithay's GLES renderer: GL driver debug-callback messages ("Buffer
+	//   detailed info: ..." on NVIDIA) per rendered frame.
+	// Default those targets to `info` unless MOONSHINE_LOG configures them
+	// explicitly (e.g. `MOONSHINE_LOG=debug,pixelforge=debug`).
+	let mut log_filter = std::env::var("MOONSHINE_LOG").unwrap_or_else(|_| "error".to_string());
+	for (target, directive) in [
+		("pixelforge", "pixelforge=info"),
+		("smithay", "smithay::backend::renderer::gles=info"),
+	] {
+		if !log_filter.contains(target) {
+			log_filter.push(',');
+			log_filter.push_str(directive);
+		}
+	}
 	tracing_subscriber::registry()
 		.with(tracing_subscriber::fmt::layer())
-		.with(EnvFilter::try_from_env("MOONSHINE_LOG").unwrap_or_else(|_| EnvFilter::new("error")))
+		.with(EnvFilter::try_new(&log_filter).unwrap_or_else(|_| EnvFilter::new("error")))
 		.init();
 
 	let mut config = Config::load_or_create(&args.config)?;


### PR DESCRIPTION
Enabling HDR in CONTROL (and other DXGI HDR games) didn't switch the stream to HDR, and once it did the colours came out heavily over-saturated. Forza Horizon 6 worked fine. This fixes that. Fixes #99.

> **Depends on hgaiser/pixelforge#15** (adds the `Bt709LinearToBt2020Pq` color space). Draft until that lands; the `pixelforge` git rev here points at that PR's branch and should be repointed to upstream once it's merged.

## Problem

CONTROL's swapchain negotiates `DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709` → `VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT` (1000104002): scRGB, i.e. **FP16 linear, BT.709 primaries**, with values > 1.0 for HDR highlights. Two things went wrong:

1. `handle_swapchain_feedback` only recognised `HDR10_ST2084` (1000104008) as HDR. scRGB fell through the `_ => {}` arm, so HDR never activated and the stream stayed SDR (this is the visible symptom in #99). Forza works because it presents a true HDR10 swapchain.
2. Naively activating HDR for it (tagging the surface BT.2020+PQ like the HDR10 path) is wrong: scRGB is linear BT.709, not BT.2020+PQ. Running BT.709-gamut pixels through the BT.2020 matrix as if already encoded produces the over-saturation, and a 10-bit UNORM render target clamps the > 1.0 highlights away.

## Fix

- Handle `EXTENDED_SRGB_LINEAR_EXT` / `EXTENDED_SRGB_NONLINEAR_EXT` in `handle_swapchain_feedback` so scRGB games activate HDR.
- Add `FrameColorSpace::Bt709Linear` (and `TransferFunction::LinearExtended`) to track scRGB **distinctly** from HDR10, so the true-HDR10 passthrough path (Forza) is untouched.
- Route scRGB frames through pixelforge's new `Bt709LinearToBt2020Pq`: BT.709→BT.2020 gamut mapping in linear light → PQ OETF, at an 80-nit scRGB reference white (IEC 61966-2-2, `1.0 == 80 cd/m²`).
- Prefer an FP16 HDR render format so scRGB highlights > 1.0 survive compositing. FP16 also holds BT.2020+PQ losslessly, so the HDR10 passthrough path is unaffected. (Fullscreen games hit direct scanout and use their own buffer regardless; this only matters for the windowed/composited fallback.)
- Preserve mastering metadata across a colorspace-feedback event instead of clobbering it, and fall the bitstream SEI back to default HDR10 metadata when the content provides none (scRGB carries no mastering metadata), matching the control-stream behaviour.

## Testing

- CONTROL: toggling HDR in-game now switches the stream to HDR with correct colours (saturation fixed, highlights preserved).
- Forza Horizon 6: still streams HDR correctly (unchanged HDR10 passthrough).
- Setup: Arch, NVIDIA, streaming to an iPad with HDR enabled in Moonlight.
