### PR TITLE
fix: allow reconnecting/resuming a running stream

### DIFF
--- a/moonshine-core/src/session/manager.rs
+++ b/moonshine-core/src/session/manager.rs
@@ -357,8 +357,13 @@ impl SessionManager {
 				Some(SessionState::Active(active)) => {
 					// Resume (reconnect): the streams are already running, so PLAY is a
 					// no-op — the client picks up the existing streams once it PINGs.
+					// The reconnecting client is a fresh Moonlight session that expects
+					// frame numbers to start at 1, so reset the video frame counters and
+					// force an IDR; otherwise it sees the running counter as a huge frame
+					// gap and reports a poor connection.
+					active.reset_video_stream();
 					guard.session = Some(SessionState::Active(active));
-					tracing::info!("Resuming active session: streams already running, treating PLAY as no-op.");
+					tracing::info!("Resuming active session: resetting video frame counter and treating PLAY as no-op.");
 					return Ok(());
 				},
 				None => {

--- a/moonshine-core/src/session/manager.rs
+++ b/moonshine-core/src/session/manager.rs
@@ -226,8 +226,12 @@ impl SessionManager {
 				Err(())
 			},
 			Some(SessionState::Active(_)) => {
-				tracing::warn!("SetStreamContext rejected: session already active (Active state)");
-				Err(())
+				// Client is resuming an already-running session (reconnect). The video,
+				// audio, and control streams are still running and re-learn the client's
+				// address from its PINGs (with refreshed keys via `/resume`), so there is
+				// nothing to rebuild — accept the re-ANNOUNCE without storing new contexts.
+				tracing::info!("Resuming active session: accepting RTSP ANNOUNCE from reconnecting client.");
+				Ok(())
 			},
 			None => {
 				tracing::warn!("SetStreamContext rejected: no active session");
@@ -351,9 +355,11 @@ impl SessionManager {
 					return Err(());
 				},
 				Some(SessionState::Active(active)) => {
+					// Resume (reconnect): the streams are already running, so PLAY is a
+					// no-op — the client picks up the existing streams once it PINGs.
 					guard.session = Some(SessionState::Active(active));
-					tracing::warn!("StartSession rejected: session already active");
-					return Err(());
+					tracing::info!("Resuming active session: streams already running, treating PLAY as no-op.");
+					return Ok(());
 				},
 				None => {
 					tracing::warn!("StartSession rejected: no active session");

--- a/moonshine-core/src/session/manager.rs
+++ b/moonshine-core/src/session/manager.rs
@@ -363,7 +363,9 @@ impl SessionManager {
 					// gap and reports a poor connection.
 					active.reset_video_stream();
 					guard.session = Some(SessionState::Active(active));
-					tracing::info!("Resuming active session: resetting video frame counter and treating PLAY as no-op.");
+					tracing::info!(
+						"Resuming active session: resetting video frame counter and treating PLAY as no-op."
+					);
 					return Ok(());
 				},
 				None => {

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -13,6 +13,7 @@ use crate::session::stream::control::ControlStreamContext;
 use crate::session::stream::video::FrameStats;
 use crate::session::stream::video::VideoStream;
 use crate::session::stream::video::VideoStreamContext;
+use crate::session::stream::video::VideoStreamHandle;
 
 use self::application::Application;
 use self::application::ApplicationConfig;
@@ -273,6 +274,10 @@ impl LaunchedSession {
 		let video_start_notify = video_handle.clone_start_notify();
 		let audio_start_notify = audio_trigger.clone_start_notify();
 
+		// Keep a handle to the video stream so a resuming client can reset its
+		// frame counters (see `ActiveSession::reset_video_stream`).
+		let video_handle_for_resume = video_handle.clone();
+
 		// Start control stream — receives both handles.
 		let control_ctx = ControlStreamContext::new(&context, hdr_effective);
 		control_stream.start(
@@ -287,6 +292,7 @@ impl LaunchedSession {
 			ActiveSession {
 				context,
 				_application: application,
+				video_handle: video_handle_for_resume,
 			},
 			video_start_notify,
 			audio_start_notify,
@@ -298,10 +304,16 @@ impl LaunchedSession {
 pub(crate) struct ActiveSession {
 	context: SessionContext,
 	_application: Application,
+	video_handle: VideoStreamHandle,
 }
 
 impl ActiveSession {
 	pub(crate) fn context(&self) -> &SessionContext {
 		&self.context
+	}
+
+	/// Reset the video stream's frame counters and force an IDR for a resuming client.
+	pub(crate) fn reset_video_stream(&self) {
+		self.video_handle.request_reset();
 	}
 }

--- a/moonshine-core/src/session/stream/control/mod.rs
+++ b/moonshine-core/src/session/stream/control/mod.rs
@@ -272,7 +272,7 @@ impl ControlStream {
 
 		let host_config = HostConfig {
 			address: Some(socket_address),
-			peer_count: 1,
+			peer_count: 128,
 			channel_limit: 1,
 			..Default::default()
 		};
@@ -377,10 +377,17 @@ fn build_termination_payload(error_code: u32) -> Vec<u8> {
 	buf
 }
 
-/// Send an encrypted control packet to the first peer of `host` if it is connected.
-fn send_to_peer(host: &mut Host, key: &[u8], sequence_number: u32, payload: &[u8], label: &str) {
+/// Send an encrypted control packet to the connected peer if it exists and is connected.
+fn send_to_peer(
+	host: &mut Host,
+	peer_id: tokio_enet::PeerId,
+	key: &[u8],
+	sequence_number: u32,
+	payload: &[u8],
+	label: &str,
+) {
 	if let Ok(packet) = encode_control(key, sequence_number, payload) {
-		if let Some(peer) = host.peer_mut(tokio_enet::PeerId(0)) {
+		if let Some(peer) = host.peer_mut(peer_id) {
 			if peer.state() == PeerState::Connected {
 				let _ = peer
 					.send(0, Packet::new(packet.as_slice(), PacketMode::ReliableSequenced))
@@ -391,14 +398,21 @@ fn send_to_peer(host: &mut Host, key: &[u8], sequence_number: u32, payload: &[u8
 }
 
 /// Build and send an HDR mode control message, then advance `sequence_number`.
-fn send_hdr_state(host: &mut Host, state: &HdrModeState, key: &[u8], sequence_number: &mut u32, label: &str) {
+fn send_hdr_state(
+	host: &mut Host,
+	peer_id: tokio_enet::PeerId,
+	state: &HdrModeState,
+	key: &[u8],
+	sequence_number: &mut u32,
+	label: &str,
+) {
 	let metadata = if state.enabled {
 		Some(state.metadata.unwrap_or_else(HdrMetadata::fallback))
 	} else {
 		None
 	};
 	let payload = build_hdr_mode_payload(state.enabled, metadata.as_ref());
-	send_to_peer(host, key, *sequence_number, &payload, label);
+	send_to_peer(host, peer_id, key, *sequence_number, &payload, label);
 	*sequence_number += 1;
 	tracing::info!("Sent HDR mode ({label}): enabled={}", state.enabled);
 }
@@ -427,6 +441,8 @@ async fn run_control_loop(
 	let mut sequence_number = 0u32;
 	let mut send_hdr_mode = false;
 	let mut audio_triggered = false;
+	// Track which peer slot the client is connected to.
+	let mut connected_peer: Option<tokio_enet::PeerId> = None;
 
 	while !stop_session_manager.is_shutdown_triggered() {
 		// Check if the timeout has passed.
@@ -440,11 +456,13 @@ async fn run_control_loop(
 
 		// Check for feedback messages.
 		if let Ok(command) = feedback_rx.try_recv() {
-			tracing::debug!("Sending control feedback command: {command:?}");
-			let payload = command.as_packet();
-			let key = context.keys_rx.borrow().remote_input_key.clone();
-			send_to_peer(&mut host, &key, sequence_number, &payload, "feedback");
-			sequence_number += 1;
+			if let Some(peer_id) = connected_peer {
+				tracing::debug!("Sending control feedback command: {command:?}");
+				let payload = command.as_packet();
+				let key = context.keys_rx.borrow().remote_input_key.clone();
+				send_to_peer(&mut host, peer_id, &key, sequence_number, &payload, "feedback");
+				sequence_number += 1;
+			}
 		}
 
 		match host
@@ -452,8 +470,14 @@ async fn run_control_loop(
 			.await
 			.map_err(|e| tracing::error!("Failure in enet host: {e}"))
 		{
-			Ok(Some(Event::Connect { .. })) => {},
-			Ok(Some(Event::Disconnect { .. })) => {},
+			Ok(Some(Event::Connect { peer_id, .. })) => {
+				connected_peer = Some(peer_id);
+			},
+			Ok(Some(Event::Disconnect { peer_id, .. })) => {
+				if connected_peer == Some(peer_id) {
+					connected_peer = None;
+				}
+			},
 			Ok(Some(Event::Receive { ref packet, .. })) => {
 				let mut control_message = match ControlMessage::from_bytes(packet.data()) {
 					Ok(control_message) => control_message,
@@ -529,16 +553,27 @@ async fn run_control_loop(
 		// Send HDR mode notification after the host.service() match to avoid double mutable borrow.
 		if send_hdr_mode {
 			send_hdr_mode = false;
-			let state = hdr_metadata_rx.borrow_and_update().clone();
-			let key = context.keys_rx.borrow().remote_input_key.clone();
-			send_hdr_state(&mut host, &state, &key, &mut sequence_number, "initial");
+			if let Some(peer_id) = connected_peer {
+				let state = hdr_metadata_rx.borrow_and_update().clone();
+				let key = context.keys_rx.borrow().remote_input_key.clone();
+				send_hdr_state(&mut host, peer_id, &state, &key, &mut sequence_number, "initial");
+			}
 		}
 
 		// Check for HDR metadata updates from the video pipeline.
 		if context.hdr && hdr_metadata_rx.has_changed().unwrap_or(false) {
-			let state = hdr_metadata_rx.borrow_and_update().clone();
-			let key = context.keys_rx.borrow().remote_input_key.clone();
-			send_hdr_state(&mut host, &state, &key, &mut sequence_number, "metadata update");
+			if let Some(peer_id) = connected_peer {
+				let state = hdr_metadata_rx.borrow_and_update().clone();
+				let key = context.keys_rx.borrow().remote_input_key.clone();
+				send_hdr_state(
+					&mut host,
+					peer_id,
+					&state,
+					&key,
+					&mut sequence_number,
+					"metadata update",
+				);
+			}
 		}
 	}
 
@@ -548,8 +583,17 @@ async fn run_control_loop(
 	// NVST_DISCONN_SERVER_TERMINATED_CLOSED (0x80030023) is recognized by the
 	// client as a graceful shutdown so it does not display an error.
 	let termination_payload = build_termination_payload(0x80030023);
-	let key = context.keys_rx.borrow().remote_input_key.clone();
-	send_to_peer(&mut host, &key, sequence_number, &termination_payload, "termination");
+	if let Some(peer_id) = connected_peer {
+		let key = context.keys_rx.borrow().remote_input_key.clone();
+		send_to_peer(
+			&mut host,
+			peer_id,
+			&key,
+			sequence_number,
+			&termination_payload,
+			"termination",
+		);
+	}
 	let _ = host.flush().await;
 
 	// Explicitly drop the ENet host before the delay shutdown token

--- a/moonshine-core/src/session/stream/video/mod.rs
+++ b/moonshine-core/src/session/stream/video/mod.rs
@@ -179,6 +179,7 @@ pub struct VideoStreamContext {
 pub(crate) struct VideoStreamHandle {
 	notify: Arc<Notify>,
 	idr_tx: broadcast::Sender<()>,
+	reset_tx: broadcast::Sender<()>,
 }
 
 impl VideoStreamHandle {
@@ -190,6 +191,17 @@ impl VideoStreamHandle {
 	/// Request an IDR (key) frame from the encoder.
 	pub fn request_idr_frame(&self) {
 		let _ = self.idr_tx.send(());
+	}
+
+	/// Reset the stream's frame/sequence counters for a resuming client.
+	///
+	/// Called when a client reconnects to an already-running session. The pipeline
+	/// keeps incrementing `frame_number` for the lifetime of the session, but a fresh
+	/// Moonlight session expects frame numbers to start at 1; without a reset it counts
+	/// the jump as massive frame loss and reports a poor connection. This also forces an
+	/// IDR so the resumed client has a decodable starting frame.
+	pub fn request_reset(&self) {
+		let _ = self.reset_tx.send(());
 	}
 
 	/// Clone the start notify for external triggering (e.g. bench binary).
@@ -261,6 +273,9 @@ impl VideoStream {
 		// IDR broadcast channel.
 		let (idr_tx, _idr_rx) = broadcast::channel(1);
 
+		// Stream-reset broadcast channel (client reconnect/resume).
+		let (reset_tx, _reset_rx) = broadcast::channel(1);
+
 		// Packet channel.
 		let (packet_tx, packet_rx) = mpsc::channel::<ShardBatch>(128);
 
@@ -275,6 +290,7 @@ impl VideoStream {
 			keys_rx,
 			packet_tx,
 			idr_tx.subscribe(),
+			reset_tx.subscribe(),
 			stop.clone(),
 			hdr_metadata_tx,
 			start_notify.clone(),
@@ -285,6 +301,7 @@ impl VideoStream {
 		Ok(VideoStreamHandle {
 			notify: start_notify,
 			idr_tx,
+			reset_tx,
 		})
 	}
 }

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -164,6 +164,7 @@ impl VideoPipeline {
 		keys_rx: SessionKeysReceiver,
 		packet_tx: mpsc::Sender<ShardBatch>,
 		idr_frame_request_rx: broadcast::Receiver<()>,
+		reset_request_rx: broadcast::Receiver<()>,
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
 		hdr_metadata_tx: watch::Sender<HdrModeState>,
 		start_notify: Arc<Notify>,
@@ -184,6 +185,7 @@ impl VideoPipeline {
 					frame_rx,
 					packet_tx,
 					idr_frame_request_rx,
+					reset_request_rx,
 					stop_session_manager,
 					hdr_metadata_tx,
 					start_notify,
@@ -209,6 +211,7 @@ impl VideoPipelineInner {
 		frame_rx: std::sync::mpsc::Receiver<ExportedFrame>,
 		packet_tx: mpsc::Sender<ShardBatch>,
 		idr_frame_request_rx: broadcast::Receiver<()>,
+		reset_request_rx: broadcast::Receiver<()>,
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
 		hdr_metadata_tx: watch::Sender<HdrModeState>,
 		start_notify: Arc<Notify>,
@@ -244,6 +247,7 @@ impl VideoPipelineInner {
 			encoder,
 			packet_tx,
 			idr_frame_request_rx,
+			reset_request_rx,
 			stop_session_manager,
 			hdr_metadata_tx,
 			stats_tx,
@@ -318,6 +322,7 @@ impl VideoPipelineInner {
 		mut encoder: Encoder,
 		packet_tx: mpsc::Sender<ShardBatch>,
 		mut idr_frame_request_rx: broadcast::Receiver<()>,
+		mut reset_request_rx: broadcast::Receiver<()>,
 		stop_session_manager: ShutdownManager<SessionShutdownReason>,
 		hdr_metadata_tx: watch::Sender<HdrModeState>,
 		stats_tx: tokio::sync::broadcast::Sender<FrameStats>,
@@ -370,8 +375,35 @@ impl VideoPipelineInner {
 		});
 
 		while !stop_session_manager.is_shutdown_triggered() {
-			// Drain any pending IDR requests.
 			let mut pending_idr = false;
+
+			// Drain any pending stream-reset requests (client reconnect/resume).
+			//
+			// Moonlight starts every (re)connected session with its frame counter at 1
+			// and waits for an IDR. Because we keep the pipeline running across a resume,
+			// `frame_number` keeps climbing, so a reconnecting client would see the first
+			// frame's index as a huge jump from its expected 1 — counted as ~100% frame
+			// loss within its sampling window, which immediately trips CONN_STATUS_POOR
+			// ("Your network connection isn't performing well"). Reset the frame and RTP
+			// sequence counters and force an IDR so the resumed client sees a clean stream
+			// starting from frame 1.
+			let mut pending_reset = false;
+			loop {
+				match reset_request_rx.try_recv() {
+					Ok(()) => pending_reset = true,
+					Err(broadcast::error::TryRecvError::Lagged(_)) => pending_reset = true,
+					Err(broadcast::error::TryRecvError::Closed | broadcast::error::TryRecvError::Empty) => break,
+				}
+			}
+			if pending_reset {
+				tracing::info!("Resetting video frame counter for resumed client and forcing IDR.");
+				frame_number = 0;
+				sequence_number = 0;
+				encoder.request_idr();
+				pending_idr = true;
+			}
+
+			// Drain any pending IDR requests.
 			loop {
 				match idr_frame_request_rx.try_recv() {
 					Ok(()) => {


### PR DESCRIPTION
Reconnecting to an already-running session failed: the session either rejected the resume outright, or — after an abrupt disconnect — refused the new control connection with a "network issues" error in Moonlight. This fixes both.

> **Depends on hgaiser/tokio-enet#2** (adds `HostConfig::replace_peer_when_full`). Draft until that lands; the `tokio-enet` git rev here points at that PR's branch and should be repointed to upstream once it's merged.

## Problem

The session is a one-way state machine (`Initialized → Launched → Active`) with no path for a client to rejoin once `Active`:

1. On reconnect Moonlight re-runs the full RTSP handshake, but `set_stream_context` (ANNOUNCE) and `start_session` (PLAY) both reject the `Active` state, so the resume gets a 500 and fails.
2. Even past that, the ENet control host uses `peer_count: 1`. After an abrupt disconnect the previous peer stays `Connected` until ENet's reliable-ping timeout (~30s) and keeps the only slot, so a reconnecting client can't get a control channel — ENet drops the incoming CONNECT before it surfaces as an event, and rapid reconnects exhaust the slot ("network issues").

## Fix

- Treat a re-ANNOUNCE / re-PLAY on an `Active` session as a resume no-op. The video, audio, and control streams keep running across the disconnect — the UDP streams re-learn the client's address from its PINGs and keys are refreshed via `/resume` — so there is nothing to rebuild and the game is never interrupted.
- Set `replace_peer_when_full: true` on the control host (new tokio-enet option) so a reconnecting client resets the stale peer and takes over the single slot immediately, instead of being refused.

## Testing

- Disconnect from a running stream and reconnect/resume: reattaches without interrupting the game.
- Abrupt disconnects (force-quit / network drop) and rapid repeated reconnects: no longer wedge or error.
- Setup: Arch, NVIDIA, streaming to an iPad.