### PR TITLE
fix: stop session when launched app exits

### DIFF
--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -1,13 +1,16 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
+use async_shutdown::ShutdownManager;
 use futures_util::StreamExt;
 use std::collections::HashMap;
+use tokio::task::JoinHandle;
 use zbus::proxy::SignalStream;
 use zbus::{Connection, MatchRule, MessageStream, Proxy};
 use zvariant::OwnedObjectPath;
 
 use crate::config::ApplicationConfig;
+use crate::session::manager::SessionShutdownReason;
 
 const SYSTEMD_BUS: &str = "org.freedesktop.systemd1";
 const SYSTEMD_PATH: &str = "/org/freedesktop/systemd1";
@@ -51,10 +54,15 @@ pub(crate) struct ApplicationContext {
 pub(crate) struct Application {
 	unit_name: String,
 	config: ApplicationConfig,
+	exit_monitor: Option<JoinHandle<()>>,
 }
 
 impl Application {
-	pub async fn spawn(config: ApplicationConfig, context: ApplicationContext) -> Result<Self, ()> {
+	pub async fn spawn(
+		config: ApplicationConfig,
+		context: ApplicationContext,
+		stop: ShutdownManager<SessionShutdownReason>,
+	) -> Result<Self, ()> {
 		let Some(program) = config.command.first() else {
 			tracing::error!("Application command is empty.");
 			return Err(());
@@ -85,18 +93,20 @@ impl Application {
 			stderr_path: &config.stderr,
 		};
 
-		match start_transient_service(&conn, &options).await {
-			Ok(()) => {},
+		let unit_path = match start_transient_service(&conn, &options).await {
+			Ok(unit_path) => unit_path,
 			Err(_) => {
 				// Best effort cleanup on launch failure.
 				stop_unit(&conn, &context.unit_name).await.ok();
 				return Err(());
 			},
 		};
+		let exit_monitor = spawn_unit_exit_monitor(conn.clone(), context.unit_name.clone(), unit_path, stop);
 
 		Ok(Self {
 			unit_name: context.unit_name,
 			config,
+			exit_monitor: Some(exit_monitor),
 		})
 	}
 }
@@ -104,6 +114,9 @@ impl Application {
 impl Drop for Application {
 	fn drop(&mut self) {
 		tracing::info!("Application '{}' is exiting.", self.config.title);
+		if let Some(handle) = self.exit_monitor.take() {
+			handle.abort();
+		}
 
 		// Unfortunately we have no `drop_async` yet, so we must spawn an async runtime to call stop_unit.
 		let unit_name = self.unit_name.clone();
@@ -281,8 +294,134 @@ async fn stop_unit_owned(unit_name: String) -> Result<(), ()> {
 	stop_unit(&conn, &unit_name).await
 }
 
+fn spawn_unit_exit_monitor(
+	conn: Connection,
+	unit_name: String,
+	unit_path: OwnedObjectPath,
+	stop: ShutdownManager<SessionShutdownReason>,
+) -> JoinHandle<()> {
+	tokio::spawn(async move {
+		tokio::select! {
+			state = wait_for_unit_terminal_state(&conn, &unit_name, &unit_path) => {
+				match state {
+					Ok(state) => {
+						tracing::info!(unit = unit_name, state, "Application unit exited; stopping session.");
+						let _ = stop.trigger_shutdown(SessionShutdownReason::ApplicationStopped);
+					},
+					Err(()) => {
+						tracing::warn!(unit = unit_name, "Application unit monitor stopped unexpectedly.");
+					},
+				}
+			},
+			_ = stop.wait_shutdown_triggered() => {},
+		}
+	})
+}
+
+async fn wait_for_unit_terminal_state(
+	conn: &Connection,
+	unit_name: &str,
+	unit_path: &OwnedObjectPath,
+) -> Result<String, ()> {
+	let proxy = Proxy::new(conn, SYSTEMD_BUS, SYSTEMD_PATH, SYSTEMD_MANAGER)
+		.await
+		.map_err(|e| tracing::error!("Failed to create systemd proxy: {e}"))?;
+	let mut unit_removed_stream = proxy
+		.receive_signal("UnitRemoved")
+		.await
+		.map_err(|e| tracing::error!("Failed to subscribe to UnitRemoved signals: {e}"))?;
+
+	let rule = MatchRule::builder()
+		.msg_type(zbus::message::Type::Signal)
+		.sender(SYSTEMD_BUS)
+		.map_err(|e| tracing::error!("Failed to create match rule: {e}"))?
+		.path(unit_path)
+		.map_err(|e| tracing::error!("Failed to create match rule: {e}"))?
+		.interface(PROPERTIES_INTERFACE)
+		.map_err(|e| tracing::error!("Failed to create match rule: {e}"))?
+		.member(PROPERTIES_CHANGED)
+		.map_err(|e| tracing::error!("Failed to create match rule: {e}"))?
+		.build();
+	let mut state_stream = MessageStream::for_match_rule(rule, conn, None)
+		.await
+		.map_err(|e| tracing::error!("Failed to create state stream: {e}"))?;
+
+	match current_unit_state(conn, unit_path).await {
+		Ok(state) => {
+			if let Some(state) = terminal_state(state.as_str()) {
+				return Ok(state.to_string());
+			}
+		},
+		Err(()) => return Ok("removed".to_string()),
+	}
+
+	loop {
+		tokio::select! {
+			message = state_stream.next() => {
+				let Some(Ok(signal)) = message else {
+					return Err(());
+				};
+				let body = signal.body();
+				let (iface, changed, _): (String, HashMap<String, zvariant::Value<'_>>, Vec<String>) =
+					body.deserialize()
+						.map_err(|e| tracing::error!("Failed to deserialize PropertiesChanged signal: {e}"))?;
+				if iface != UNIT_INTERFACE {
+					continue;
+				}
+				if let Some(zvariant::Value::Str(state)) = changed.get(ACTIVE_STATE_PROPERTY) {
+					if let Some(state) = terminal_state(state.as_str()) {
+						return Ok(state.to_string());
+					}
+				}
+			},
+			message = unit_removed_stream.next() => {
+				let Some(message) = message else {
+					return Err(());
+				};
+				let (id, _path): (String, OwnedObjectPath) = message
+					.body()
+					.deserialize()
+					.map_err(|e| tracing::error!("Failed to deserialize UnitRemoved signal: {e}"))?;
+				if id == unit_name {
+					return Ok("removed".to_string());
+				}
+			},
+		}
+	}
+}
+
+async fn current_unit_state(conn: &Connection, unit_path: &OwnedObjectPath) -> Result<String, ()> {
+	let reply = conn
+		.call_method(
+			Some(SYSTEMD_BUS),
+			unit_path,
+			Some(PROPERTIES_INTERFACE),
+			"Get",
+			&(UNIT_INTERFACE, ACTIVE_STATE_PROPERTY),
+		)
+		.await
+		.map_err(|e| tracing::error!("Failed to get unit state: {e}"))?;
+
+	let body = reply.body();
+	let (variant,): (zvariant::Value<'_>,) = body.deserialize().map_err(|e| {
+		tracing::error!("Failed to deserialize unit state: {e}");
+	})?;
+	match variant {
+		zvariant::Value::Str(state) => Ok(state.to_string()),
+		_ => Ok("unknown".to_string()),
+	}
+}
+
+fn terminal_state(state: &str) -> Option<&'static str> {
+	match state {
+		"inactive" => Some("inactive"),
+		"failed" => Some("failed"),
+		_ => None,
+	}
+}
+
 /// Launch the application as a transient systemd service unit via D-Bus.
-async fn start_transient_service(conn: &Connection, options: &LaunchOptions<'_>) -> Result<(), ()> {
+async fn start_transient_service(conn: &Connection, options: &LaunchOptions<'_>) -> Result<OwnedObjectPath, ()> {
 	// Resolve exec entries in a blocking task — `which::which` does filesystem lookups.
 	let (pre_entries, main_entry, post_entries) = tokio::task::spawn_blocking({
 		let pre_commands = options.pre_commands.clone();
@@ -401,26 +540,8 @@ async fn start_transient_service(conn: &Connection, options: &LaunchOptions<'_>)
 		.map_err(|e| tracing::error!("Failed to deserialize unit object path: {e}"))?;
 
 	// Check current state before subscribing — catches apps that exit immediately.
-	let reply = conn
-		.call_method(
-			Some(SYSTEMD_BUS),
-			&path,
-			Some(PROPERTIES_INTERFACE),
-			"Get",
-			&(UNIT_INTERFACE, ACTIVE_STATE_PROPERTY),
-		)
-		.await
-		.map_err(|e| tracing::error!("Failed to get unit state: {e}"))?;
-
-	let body = reply.body();
-	let (variant,): (zvariant::Value<'_>,) = body.deserialize().map_err(|e| {
-		tracing::error!("Failed to deserialize unit state: {e}");
-	})?;
-	let state = match variant {
-		zvariant::Value::Str(s) => s.to_string(),
-		_ => "unknown".to_string(),
-	};
-	if state == "failed" || state == "inactive" {
+	let state = current_unit_state(conn, &path).await?;
+	if terminal_state(&state).is_some() {
 		tracing::warn!(state = state, "Application exited immediately after launch.");
 		return Err(());
 	}
@@ -469,13 +590,13 @@ async fn start_transient_service(conn: &Connection, options: &LaunchOptions<'_>)
 		Ok(Ok(())) => {
 			// Timeout expired — unit is still alive, launch succeeded.
 			tracing::info!("Application launched in service {}", options.unit_name);
-			Ok(())
+			Ok(path)
 		},
 		Ok(Err(())) => Err(()),
 		Err(_) => {
 			// Timeout expired — unit is still alive, launch succeeded.
 			tracing::info!("Application launched in service {}", options.unit_name);
-			Ok(())
+			Ok(path)
 		},
 	}
 }

--- a/moonshine-core/src/session/manager.rs
+++ b/moonshine-core/src/session/manager.rs
@@ -22,6 +22,8 @@ pub(crate) enum SessionShutdownReason {
 	ManagerShutdown,
 	/// The session was stopped by the user.
 	UserStopped,
+	/// The launched application exited.
+	ApplicationStopped,
 	/// Video packet handler stopped unexpectedly.
 	VideoPacketHandlerStopped,
 	/// Video encoder stopped unexpectedly.

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -125,6 +125,7 @@ pub(crate) struct InitializedSession {
 	video_stream: VideoStream,
 	control_stream: ControlStream,
 	hdr_metadata_rx: watch::Receiver<HdrModeState>,
+	stop: ShutdownManager<SessionShutdownReason>,
 }
 
 impl InitializedSession {
@@ -149,6 +150,7 @@ impl InitializedSession {
 			video_stream,
 			control_stream,
 			hdr_metadata_rx,
+			stop,
 		})
 	}
 
@@ -165,6 +167,7 @@ impl InitializedSession {
 			video_stream,
 			control_stream,
 			hdr_metadata_rx,
+			stop,
 		} = self;
 
 		let launched_compositor = compositor.launch()?;
@@ -180,6 +183,7 @@ impl InitializedSession {
 				wayland_display: ready.wayland_display.clone(),
 				hdr: ready.hdr,
 			},
+			stop,
 		)
 		.await?;
 


### PR DESCRIPTION
Quitting Steam from inside a stream left Moonlight connected to a black screen. The application process had exited, but Moonshine kept the compositor and streams alive until the client explicitly sent `/cancel` or a stream timeout fired.

## Problem

Applications are launched as transient user systemd units (`moonshine-session.service`). Launch already checked that the unit survived startup, but after launch Moonshine dropped the D-Bus subscription and only kept an `Application` value so the unit could be stopped when the session was dropped.

That made the lifecycle one-way: session shutdown stopped the app, but the app exiting did not stop the session. Closing Steam therefore removed the visible content while the compositor/video/audio/control streams continued running, which appears in Moonlight as a black screen that never ends automatically.

## Fix

- Keep a small monitor task on the launched application unit after startup succeeds.
- Watch for `ActiveState=inactive`, `ActiveState=failed`, or `UnitRemoved` and trigger session shutdown with a new `ApplicationStopped` reason.
- Abort the monitor when the session is intentionally stopped, so `/cancel` and normal teardown continue to own app cleanup.

This does not require Moonshine itself to run under systemd; it only watches the transient user unit Moonshine already creates for the launched app.

## Testing

- `cargo build -p moonshine-core`
- `cargo test -p moonshine-core`
- `cargo build --release -p moonshine-core`

Runtime case to verify: launch Steam via Moonlight, quit Steam fully, and the Moonlight session should end instead of staying on a black screen.