### PR TITLE
fix: only write ANSI color escapes when stdout is a terminal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use async_shutdown::ShutdownManager;
@@ -27,7 +28,9 @@ async fn main() -> Result<(), ()> {
 	let args = Args::parse();
 
 	tracing_subscriber::registry()
-		.with(tracing_subscriber::fmt::layer())
+		// Only color when stdout is a terminal: under systemd the escape codes
+		// make journald store every MESSAGE as a byte array instead of a string.
+		.with(tracing_subscriber::fmt::layer().with_ansi(std::io::stdout().is_terminal()))
 		.with(EnvFilter::try_from_env("MOONSHINE_LOG").unwrap_or_else(|_| EnvFilter::new("error")))
 		.init();
 


### PR DESCRIPTION
The fmt layer colors unconditionally, so when moonshine runs under systemd every log line carries escape codes and journald stores MESSAGE as a byte array instead of a string. Anything consuming `journalctl -o json` (and some plain journalctl setups) has to decode the bytes and strip the escapes before it can read a line.

This gates ansi on stdout being a terminal. Interactive output is unchanged.

Found this while building a small bench harness that parses the frame latency summaries out of the journal on NixOS. Verified the patched build under systemd: MESSAGE comes through as a plain string.
