### PR TITLE
Feature: Pass client screen infos as env args to host

### DIFF
--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -107,6 +107,8 @@ pub(crate) struct ApplicationContext {
 	pub wayland_display: String,
 	/// Effective HDR mode — `true` only when the compositor confirmed an HDR-capable DMA-BUF format is in use.
 	pub hdr: bool,
+	/// Environment variables to pass on
+	pub extra_env: HashMap<String, String>,
 }
 
 pub(crate) struct Application {
@@ -207,6 +209,10 @@ fn make_envs(context: &ApplicationContext) -> Result<Vec<String>, ()> {
 		// SDR sessions too, so we need an explicit capability signal).
 		envs.push("MOONSHINE_HDR=1".to_string());
 	}
+
+	for (key, value) in &context.extra_env {
+        envs.push(format!("{key}={value}"));
+    }
 
 	Ok(envs)
 }

--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -107,7 +107,7 @@ pub(crate) struct ApplicationContext {
 	pub wayland_display: String,
 	/// Effective HDR mode — `true` only when the compositor confirmed an HDR-capable DMA-BUF format is in use.
 	pub hdr: bool,
-	/// Environment variables to pass on
+	/// Environment variables to pass on.
 	pub extra_env: HashMap<String, String>,
 }
 

--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -211,8 +211,8 @@ fn make_envs(context: &ApplicationContext) -> Result<Vec<String>, ()> {
 	}
 
 	for (key, value) in &context.extra_env {
-        envs.push(format!("{key}={value}"));
-    }
+    	envs.push(format!("{key}={value}"));
+	}
 
 	Ok(envs)
 }

--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -211,7 +211,7 @@ fn make_envs(context: &ApplicationContext) -> Result<Vec<String>, ()> {
 	}
 
 	for (key, value) in &context.extra_env {
-    	envs.push(format!("{key}={value}"));
+		envs.push(format!("{key}={value}"));
 	}
 
 	Ok(envs)

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+ use std::collections::HashMap;
 
 use async_shutdown::ShutdownManager;
 use manager::SessionShutdownReason;
@@ -200,6 +201,12 @@ impl InitializedSession {
 				xdisplay: ready.xdisplay,
 				wayland_display: ready.wayland_display.clone(),
 				hdr: ready.hdr,
+				// Populate extra_env with width, height and refreshrate values of the client for e.g. scripting
+				extra_env: HashMap::from([
+			        ("MOONSHINE_CLIENT_WIDTH".to_string(), context.resolution.0.to_string()),
+			        ("MOONSHINE_CLIENT_HEIGHT".to_string(), context.resolution.1.to_string()),
+			        ("MOONSHINE_CLIENT_FRAMERATE".to_string(), context.refresh_rate.to_string()),
+			    ]),
 			},
 		)
 		.await?;

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -203,12 +203,12 @@ impl InitializedSession {
 				hdr: ready.hdr,
 				// Populate extra_env with width, height and refreshrate values of the client for e.g. scripting
 				extra_env: HashMap::from([
-			    	("MOONSHINE_CLIENT_WIDTH".to_string(), context.resolution.0.to_string()),
-			    	("MOONSHINE_CLIENT_HEIGHT".to_string(), context.resolution.1.to_string()),
-			    	(
-			    		"MOONSHINE_CLIENT_FRAMERATE".to_string(),
-			    		context.refresh_rate.to_string()
-		    		),
+					("MOONSHINE_CLIENT_WIDTH".to_string(), context.resolution.0.to_string()),
+					("MOONSHINE_CLIENT_HEIGHT".to_string(), context.resolution.1.to_string()),
+					(
+						"MOONSHINE_CLIENT_FRAMERATE".to_string(),
+						context.refresh_rate.to_string(),
+					),
 				]),
 			},
 		)

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
- use std::collections::HashMap;
+use std::collections::HashMap;
 
 use async_shutdown::ShutdownManager;
 use manager::SessionShutdownReason;

--- a/moonshine-core/src/session/mod.rs
+++ b/moonshine-core/src/session/mod.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_shutdown::ShutdownManager;
 use manager::SessionShutdownReason;
@@ -203,10 +203,13 @@ impl InitializedSession {
 				hdr: ready.hdr,
 				// Populate extra_env with width, height and refreshrate values of the client for e.g. scripting
 				extra_env: HashMap::from([
-			        ("MOONSHINE_CLIENT_WIDTH".to_string(), context.resolution.0.to_string()),
-			        ("MOONSHINE_CLIENT_HEIGHT".to_string(), context.resolution.1.to_string()),
-			        ("MOONSHINE_CLIENT_FRAMERATE".to_string(), context.refresh_rate.to_string()),
-			    ]),
+			    	("MOONSHINE_CLIENT_WIDTH".to_string(), context.resolution.0.to_string()),
+			    	("MOONSHINE_CLIENT_HEIGHT".to_string(), context.resolution.1.to_string()),
+			    	(
+			    		"MOONSHINE_CLIENT_FRAMERATE".to_string(),
+			    		context.refresh_rate.to_string()
+		    		),
+				]),
 			},
 		)
 		.await?;


### PR DESCRIPTION
I don't know how widely applicable/helpful this is to other users, but this is a must have for me.
Some of my steam games (e.g. Forza Horizon 6) realy do not play well with the smithay compositor that is builtin to moonshine.

Forza creates multiple windows, one being black and the other displaying the actual game, but the focus mechanism in moonshine pics the black window.
This may be only an issue on my machine, as a friend's pc with same brand components does not do this.

In my case the usage of Gamescope in Steam's launch args fixes this. But I am frequently switching between different resolution devices, so hardcoding display infos is not a viable option; for me at least.

Hence, this PR that communicates just that using environment variables.