### PR TITLE
feat: replace avahi/zeroconf with embedded mdns-sd responder

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -6,7 +6,6 @@ runs:
     - name: Install dependencies
       run: |
         sudo pacman -Syyuu --noconfirm --needed \
-          avahi \
           clang \
           cmake \
           gcc-libs \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -205,7 +205,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -217,7 +217,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -354,7 +354,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -421,16 +421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "avahi-sys"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e00c83b3887835fd326daae1b2c4e7a435405033331a876ae1dd03f77b8274"
-dependencies = [
- "bindgen 0.69.5",
- "libc",
-]
-
-[[package]]
 name = "avif-serialize"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,29 +466,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.117",
- "which 4.4.2",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
@@ -516,7 +483,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.117",
+ "syn",
  "which 4.4.2",
 ]
 
@@ -582,16 +549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bonjour-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8655c4daf1447c831970e4134e8312a15c63fbff109b353cfe934c22f2b61a"
-dependencies = [
- "bindgen 0.68.1",
- "libc",
-]
-
-[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,7 +586,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -749,7 +706,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
@@ -761,7 +718,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -924,41 +881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
-name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.9.3",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
-dependencies = [
- "darling_core",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "dasp"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,53 +1040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-getters"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2c35ab6e03642397cdda1dd58abbc05d418aef8e36297f336d5aba060fe8df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
-dependencies = [
- "darling",
- "derive_builder_core",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1089,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1307,7 +1182,7 @@ checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
 dependencies = [
  "num-traits",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1328,7 +1203,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1348,7 +1223,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1432,7 +1307,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1470,10 +1345,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
+name = "flume"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "foldhash"
@@ -1565,7 +1445,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1933,12 +1813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1831,16 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2034,7 +1918,7 @@ name = "inputtino-sys"
 version = "0.1.0"
 source = "git+https://github.com/games-on-whales/inputtino#f4ce2b0df536ef309e9ff318f75b460f7097d7c1"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cmake",
 ]
 
@@ -2046,7 +1930,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2237,6 +2121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2280,6 +2173,21 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892f96f6d2ebe1ea641279f986ac52a2a6bac71e8f743bb258315cfe2bd7e88e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio 1.2.0",
+ "socket-pktinfo",
+ "socket2 0.6.3",
 ]
 
 [[package]]
@@ -2397,6 +2305,7 @@ dependencies = [
  "dirs",
  "fec-rs",
  "futures-util",
+ "gethostname",
  "hex",
  "http-body-util",
  "hyper",
@@ -2404,6 +2313,7 @@ dependencies = [
  "image",
  "inputtino",
  "libc",
+ "mdns-sd",
  "mio 1.2.0",
  "mio-timerfd",
  "network-interface",
@@ -2441,7 +2351,6 @@ dependencies = [
  "x509-parser",
  "xcursor",
  "zbus",
- "zeroconf",
  "zvariant",
 ]
 
@@ -2593,7 +2502,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2764,12 +2673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2971,7 +2874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3441,7 +3344,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3465,7 +3368,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3601,6 +3504,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2 0.6.3",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3625,6 +3539,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -3658,12 +3575,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3677,7 +3588,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3685,17 +3596,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -3716,7 +3616,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3770,7 +3670,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3781,7 +3681,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3900,7 +3800,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3984,7 +3884,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4208,7 +4108,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4469,7 +4369,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4480,7 +4380,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4529,7 +4429,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -4547,14 +4456,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4582,10 +4508,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4594,10 +4532,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4606,10 +4556,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4618,10 +4580,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4678,7 +4652,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4694,7 +4668,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4840,7 +4814,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -4888,7 +4862,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -4903,32 +4877,6 @@ dependencies = [
  "serde",
  "winnow",
  "zvariant",
-]
-
-[[package]]
-name = "zeroconf"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e2acf5ff420bad258a6f8cc590a3361c8ddb8176077eb4714afa13e0d3d6b"
-dependencies = [
- "avahi-sys",
- "bonjour-sys",
- "derive-getters",
- "derive-new",
- "derive_builder",
- "libc",
- "log",
- "zeroconf-macros",
-]
-
-[[package]]
-name = "zeroconf-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b52318880bad5d5a081f7ac4251b5144e73dfa859cbcd10562d9433eeed6b72"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4948,7 +4896,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4968,7 +4916,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -5008,7 +4956,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5064,7 +5012,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "zvariant_utils",
 ]
 
@@ -5077,6 +5025,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn",
  "winnow",
 ]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ The following dependencies are required to build:
 
 ```sh
 sudo pacman -S \
-   avahi \
    clang \
    cmake \
    gcc-libs \

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -56,8 +56,8 @@ url = "2.5.8"
 notify-rust = "4.12.0"
 
 # Discovery
-gethostname = "1.0"
-mdns-sd = "0.20"
+gethostname = "1.1.0"
+mdns-sd = "0.20.0"
 
 # Session (compositor)
 ash = { git = "https://github.com/ash-rs/ash", rev = "55dd56906bbb5760e9e9e6c56f45be67f67e0649" }

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -56,7 +56,8 @@ url = "2.5.8"
 notify-rust = "4.12.0"
 
 # Discovery
-zeroconf = "0.17.0"
+gethostname = "1.0"
+mdns-sd = "0.20"
 
 # Session (compositor)
 ash = { git = "https://github.com/ash-rs/ash", rev = "55dd56906bbb5760e9e9e6c56f45be67f67e0649" }

--- a/moonshine-core/src/discovery.rs
+++ b/moonshine-core/src/discovery.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use mdns_sd::{IfKind, ServiceDaemon, ServiceInfo};
+use network_interface::NetworkInterfaceConfig;
 
 const SERVICE_TYPE: &str = "_nvstream._tcp.local.";
 
@@ -46,11 +47,7 @@ fn register(address: &str, port: u16, name: &str) -> Result<(ServiceDaemon, Stri
 	let hostname = format!("{machine_name}-moonshine.local.");
 
 	let mode = advertise_mode(address);
-	if mode == Advertise::Ipv4Only {
-		daemon.disable_interface(IfKind::IPv6)?;
-	}
-
-	let service = match mode {
+	let mut service = match mode {
 		Advertise::Fixed(ip) => ServiceInfo::new(
 			SERVICE_TYPE,
 			name,
@@ -70,11 +67,62 @@ fn register(address: &str, port: u16, name: &str) -> Result<(ServiceDaemon, Stri
 		.enable_addr_auto(),
 	};
 
+	match mode {
+		Advertise::All => service.set_interfaces(auto_service_interfaces(true)),
+		Advertise::Ipv4Only => service.set_interfaces(auto_service_interfaces(false)),
+		Advertise::Fixed(_) => {},
+	}
+
 	let fullname = service.get_fullname().to_string();
 	daemon.register(service)?;
 	tracing::debug!("Advertising service '{fullname}' with hostname '{hostname}'.");
 
 	Ok((daemon, fullname))
+}
+
+fn auto_service_interfaces(include_ipv6: bool) -> Vec<IfKind> {
+	let mut ipv4_indexes = Vec::new();
+	let mut ipv6_indexes = Vec::new();
+
+	match network_interface::NetworkInterface::show() {
+		Ok(interfaces) => {
+			for interface in interfaces {
+				if interface.internal {
+					continue;
+				}
+
+				for addr in interface.addr {
+					match addr.ip() {
+						IpAddr::V4(ip) if !ip.is_loopback() && !ipv4_indexes.contains(&interface.index) => {
+							ipv4_indexes.push(interface.index);
+						},
+						IpAddr::V6(ip)
+							if include_ipv6 && !ip.is_loopback() && !ipv6_indexes.contains(&interface.index) =>
+						{
+							ipv6_indexes.push(interface.index);
+						},
+						_ => {},
+					}
+				}
+			}
+		},
+		Err(e) => tracing::warn!("Failed to retrieve network interfaces for mDNS advertisement: {e}"),
+	}
+
+	if ipv4_indexes.is_empty() && ipv6_indexes.is_empty() {
+		let fallback = if include_ipv6 { IfKind::All } else { IfKind::IPv4 };
+		tracing::warn!(
+			"No non-loopback interface found for mDNS advertisement; falling back to {:?} interfaces.",
+			fallback
+		);
+		return vec![fallback];
+	}
+
+	ipv4_indexes
+		.into_iter()
+		.map(IfKind::IndexV4)
+		.chain(ipv6_indexes.into_iter().map(IfKind::IndexV6))
+		.collect()
 }
 
 impl Drop for MdnsDiscovery {

--- a/moonshine-core/src/discovery.rs
+++ b/moonshine-core/src/discovery.rs
@@ -72,3 +72,60 @@ fn on_service_registered(
 		tracing::debug!("Service successfully registered.");
 	}
 }
+
+/// Which addresses to advertise over mDNS, derived from the configured bind address.
+#[derive(Debug, PartialEq)]
+enum Advertise {
+	/// Advertise all host addresses (IPv4 and IPv6), tracking changes.
+	All,
+	/// Advertise all host IPv4 addresses, tracking changes.
+	Ipv4Only,
+	/// Advertise exactly this address.
+	Fixed(std::net::IpAddr),
+}
+
+fn advertise_mode(address: &str) -> Advertise {
+	match address.parse::<std::net::IpAddr>() {
+		Ok(ip) if ip.is_unspecified() => {
+			if ip.is_ipv4() {
+				Advertise::Ipv4Only
+			} else {
+				Advertise::All
+			}
+		},
+		Ok(ip) => Advertise::Fixed(ip),
+		// The configured address is a hostname; we can't tell which addresses it
+		// resolves to, so advertise everything.
+		Err(_) => Advertise::All,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn unspecified_ipv6_advertises_all() {
+		assert_eq!(advertise_mode("::"), Advertise::All);
+	}
+
+	#[test]
+	fn unspecified_ipv4_advertises_ipv4_only() {
+		assert_eq!(advertise_mode("0.0.0.0"), Advertise::Ipv4Only);
+	}
+
+	#[test]
+	fn specific_ipv4_is_fixed() {
+		assert_eq!(advertise_mode("192.168.1.5"), Advertise::Fixed("192.168.1.5".parse().unwrap()));
+	}
+
+	#[test]
+	fn specific_ipv6_is_fixed() {
+		assert_eq!(advertise_mode("fd12:3456::1"), Advertise::Fixed("fd12:3456::1".parse().unwrap()));
+	}
+
+	#[test]
+	fn hostname_falls_back_to_all() {
+		assert_eq!(advertise_mode("localhost"), Advertise::All);
+	}
+}

--- a/moonshine-core/src/discovery.rs
+++ b/moonshine-core/src/discovery.rs
@@ -1,75 +1,91 @@
-use async_shutdown::ShutdownManager;
-use zeroconf::prelude::*;
+use std::collections::HashMap;
+use std::net::IpAddr;
 
-use crate::ShutdownReason;
+use mdns_sd::{IfKind, ServiceDaemon, ServiceInfo};
 
-pub struct ZeroconfDiscovery {
-	handle: Option<std::thread::JoinHandle<()>>,
-}
+const SERVICE_TYPE: &str = "_nvstream._tcp.local.";
 
-impl ZeroconfDiscovery {
-	pub fn spawn(port: u16, name: String, shutdown: ShutdownManager<ShutdownReason>) -> Self {
-		let handle = std::thread::spawn(move || run(port, name, shutdown));
-		Self { handle: Some(handle) }
-	}
-}
-
-impl Drop for ZeroconfDiscovery {
-	fn drop(&mut self) {
-		// No timeout: the OS reclaims all thread resources on process exit anyway,
-		// and a blocked join during shutdown would only delay SIGKILL escalation.
-		if let Some(handle) = self.handle.take() {
-			handle.join().ok();
-		}
-	}
-}
-
-/// Runs the mDNS publisher in a separate thread, advertising the service until shutdown is triggered.
+/// Advertises the Moonshine service over mDNS until dropped.
 ///
-/// Errors do not trigger a global shutdown as this service is not considered critical for the main functionality.
-fn run(port: u16, name: String, shutdown: ShutdownManager<ShutdownReason>) {
-	let service_type = match zeroconf::ServiceType::new("nvstream", "tcp") {
-		Ok(service_type) => service_type,
-		Err(e) => {
-			tracing::error!("Failed to advertise Moonshine service: {e}");
-			return;
-		},
-	};
-	let mut service = zeroconf::MdnsService::new(service_type, port);
+/// This embeds its own responder (no avahi-daemon required). It coexists with a
+/// running avahi-daemon: both bind UDP 5353 with SO_REUSEPORT, and we advertise a
+/// hostname distinct from the machine's `<hostname>.local` so avahi never sees
+/// conflicting unique records (which would trigger its conflict resolution and a
+/// `<hostname>-2.local` rename).
+pub struct MdnsDiscovery {
+	daemon: Option<ServiceDaemon>,
+	fullname: String,
+}
 
-	service.set_registered_callback(Box::new(on_service_registered));
-	service.set_name(&name);
-	service.set_network_interface(zeroconf::NetworkInterface::Unspec);
-
-	let event_loop = match service.register() {
-		Ok(loop_) => loop_,
-		Err(e) => {
-			tracing::error!("Failed to register mDNS service: {e}");
-			return;
-		},
-	};
-
-	loop {
-		if shutdown.is_shutdown_triggered() {
-			tracing::debug!("Publisher received shutdown signal, stopping.");
-			break;
+impl MdnsDiscovery {
+	/// Start advertising. Errors are logged and otherwise ignored, as discovery is
+	/// not critical: clients can still add the host manually.
+	pub fn spawn(address: &str, port: u16, name: &str) -> Self {
+		match register(address, port, name) {
+			Ok((daemon, fullname)) => Self {
+				daemon: Some(daemon),
+				fullname,
+			},
+			Err(e) => {
+				tracing::error!("Failed to advertise Moonshine service: {e}");
+				Self {
+					daemon: None,
+					fullname: String::new(),
+				}
+			},
 		}
-
-		if let Err(e) = event_loop.poll(std::time::Duration::from_secs(0)) {
-			tracing::warn!("Failed to publish service: {e}");
-		}
-		std::thread::sleep(std::time::Duration::from_secs(1));
 	}
 }
 
-fn on_service_registered(
-	result: zeroconf::Result<zeroconf::ServiceRegistration>,
-	_context: Option<std::sync::Arc<dyn std::any::Any + Send + Sync + 'static>>,
-) {
-	if let Err(e) = result {
-		tracing::error!("Failed to register service: {e}");
-	} else {
-		tracing::debug!("Service successfully registered.");
+fn register(address: &str, port: u16, name: &str) -> Result<(ServiceDaemon, String), mdns_sd::Error> {
+	let daemon = ServiceDaemon::new()?;
+
+	let machine_name = gethostname::gethostname();
+	let machine_name = machine_name.to_string_lossy();
+	let machine_name = machine_name.split('.').next().unwrap_or("host");
+	let hostname = format!("{machine_name}-moonshine.local.");
+
+	let mode = advertise_mode(address);
+	if mode == Advertise::Ipv4Only {
+		daemon.disable_interface(IfKind::IPv6)?;
+	}
+
+	let service = match mode {
+		Advertise::Fixed(ip) => ServiceInfo::new(
+			SERVICE_TYPE,
+			name,
+			&hostname,
+			ip,
+			port,
+			HashMap::<String, String>::new(),
+		)?,
+		_ => ServiceInfo::new(
+			SERVICE_TYPE,
+			name,
+			&hostname,
+			"",
+			port,
+			HashMap::<String, String>::new(),
+		)?
+		.enable_addr_auto(),
+	};
+
+	let fullname = service.get_fullname().to_string();
+	daemon.register(service)?;
+	tracing::debug!("Advertising service '{fullname}' with hostname '{hostname}'.");
+
+	Ok((daemon, fullname))
+}
+
+impl Drop for MdnsDiscovery {
+	fn drop(&mut self) {
+		if let Some(daemon) = self.daemon.take() {
+			// Unregister first so goodbye packets are sent, then stop the daemon thread.
+			if let Ok(receiver) = daemon.unregister(&self.fullname) {
+				let _ = receiver.recv_timeout(std::time::Duration::from_secs(2));
+			}
+			let _ = daemon.shutdown();
+		}
 	}
 }
 
@@ -81,11 +97,11 @@ enum Advertise {
 	/// Advertise all host IPv4 addresses, tracking changes.
 	Ipv4Only,
 	/// Advertise exactly this address.
-	Fixed(std::net::IpAddr),
+	Fixed(IpAddr),
 }
 
 fn advertise_mode(address: &str) -> Advertise {
-	match address.parse::<std::net::IpAddr>() {
+	match address.parse::<IpAddr>() {
 		Ok(ip) if ip.is_unspecified() => {
 			if ip.is_ipv4() {
 				Advertise::Ipv4Only
@@ -116,12 +132,18 @@ mod tests {
 
 	#[test]
 	fn specific_ipv4_is_fixed() {
-		assert_eq!(advertise_mode("192.168.1.5"), Advertise::Fixed("192.168.1.5".parse().unwrap()));
+		assert_eq!(
+			advertise_mode("192.168.1.5"),
+			Advertise::Fixed("192.168.1.5".parse().unwrap())
+		);
 	}
 
 	#[test]
 	fn specific_ipv6_is_fixed() {
-		assert_eq!(advertise_mode("fd12:3456::1"), Advertise::Fixed("fd12:3456::1".parse().unwrap()));
+		assert_eq!(
+			advertise_mode("fd12:3456::1"),
+			Advertise::Fixed("fd12:3456::1".parse().unwrap())
+		);
 	}
 
 	#[test]

--- a/moonshine-core/src/webserver/mod.rs
+++ b/moonshine-core/src/webserver/mod.rs
@@ -338,7 +338,7 @@ impl Webserver {
 
 		let response = if https {
 			match (request.method(), request.uri().path()) {
-				(&Method::GET, "/serverinfo") => self.server_info(params, mac_address, https).await,
+				(&Method::GET, "/serverinfo") => self.server_info(params, local_address, mac_address, https).await,
 				(&Method::GET, "/applist") => {
 					if let Some(resp) = self.verify_paired_client(&peer_cert_fingerprint) {
 						return Ok(resp);
@@ -393,7 +393,7 @@ impl Webserver {
 			}
 		} else {
 			match (request.method(), request.uri().path()) {
-				(&Method::GET, "/serverinfo") => self.server_info(params, mac_address, https).await,
+				(&Method::GET, "/serverinfo") => self.server_info(params, local_address, mac_address, https).await,
 				(&Method::GET, "/pair") => {
 					if !self.webserver_config.enable_pairing {
 						tracing::warn!("Pairing is disabled in configuration.");
@@ -539,6 +539,7 @@ impl Webserver {
 	async fn server_info(
 		&self,
 		params: HashMap<String, String>,
+		local_address: Option<SocketAddr>,
 		mac_address: Option<String>,
 		https: bool,
 	) -> Response<Full<Bytes>> {
@@ -561,6 +562,8 @@ impl Webserver {
 			"0"
 		};
 
+		let local_ip = local_address.map(|addr| addr.ip().to_string()).unwrap_or_default();
+
 		// TODO: Check the use of some of these values, we leave most of them blank and Moonlight doesn't care.
 		let mut response = "<root status_code=\"200\">".to_string();
 		response += &format!("<hostname>{}</hostname>", escape_xml(&self.hostname));
@@ -571,7 +574,7 @@ impl Webserver {
 		response += "<ExternalPort></ExternalPort>";
 		response += &format!("<mac>{}</mac>", mac_address.unwrap_or("".to_string()));
 		response += "<MaxLumaPixelsHEVC>1869449984</MaxLumaPixelsHEVC>"; // TODO: Check if HEVC is supported, set this to 0 if it is not.
-		response += "<LocalIP></LocalIP>";
+		response += &format!("<LocalIP>{}</LocalIP>", escape_xml(local_ip));
 		let server_codec_mode_support = (ServerCodecModeSupport::H264 as u32)
 			| (ServerCodecModeSupport::H264High8444 as u32)
 			| (ServerCodecModeSupport::Hevc as u32)

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::EnvFilter;
 
 use moonshine_core::clients::ClientManager;
 use moonshine_core::config::Config;
-use moonshine_core::discovery::ZeroconfDiscovery;
+use moonshine_core::discovery::MdnsDiscovery;
 use moonshine_core::rtsp::RtspServer;
 use moonshine_core::session::manager::SessionManager;
 use moonshine_core::webserver::Webserver;
@@ -72,7 +72,7 @@ pub struct Moonshine {
 	_session_manager: SessionManager,
 	_client_manager: ClientManager,
 	_webserver: Webserver,
-	_discovery: ZeroconfDiscovery,
+	_discovery: MdnsDiscovery,
 }
 
 impl Moonshine {
@@ -115,7 +115,7 @@ impl Moonshine {
 				session_manager,
 				shutdown.clone(),
 			)?,
-			_discovery: ZeroconfDiscovery::spawn(config.webserver.port, config.name, shutdown),
+			_discovery: MdnsDiscovery::spawn(&config.address, config.webserver.port, &config.name),
 		})
 	}
 }


### PR DESCRIPTION
## Problem

Discovery currently goes through the `zeroconf` crate, which is a binding to avahi — so avahi is both a build dependency and a hard runtime dependency. In the review of #100 the preference was to drop avahi entirely rather than keep working around it.

The main reason for me working on this is that there is also a discovery-side half of the flip-flop bug from #100: avahi advertises both A and AAAA records by default, while the webserver only listened on IPv4, so Moonlight alternates between a working IPv4 address and a dead IPv6 one. (As detailed in #100) this was super annoying in Moonlight and made it hard to connect sometimes.

## Fix

- Replace `zeroconf`/avahi with the pure-Rust `mdns-sd` responder (plus `gethostname`). No external daemon needed; avahi is removed from the README and CI package lists (`clang` stays — other crates need it).
- Advertised addresses follow `config.address`:
  - `::` → all interface addresses (IPv4 + IPv6)
  - `0.0.0.0` → IPv4 only
  - a specific IP → just that IP
  
  Since the default (`0.0.0.0`) now advertises IPv4 only, this fixes the online/offline flip-flop that #100 also fixed(ish). It's complementary to that PR (which fixes the webserver-binding half) — they merge cleanly in either order, and this PR doesn't touch config defaults or the webserver.  
- Coexistence with a running avahi: the SRV target is a unique hostname (`<machine>-moonshine.local.`) instead of the machine hostname avahi already owns, so avahi never sees a conflicting unique record. Sharing UDP 5353 is fine (both use `SO_REUSEPORT`), and a shared PTR record is explicitly allowed by RFC 6762. Verified Moonlight resolves whatever SRV target we publish.

## Known limitations

- If avahi is configured with `disallow-other-stacks=yes`, the socket can't be bound: Moonshine logs an error and runs with discovery off (manual add in Moonlight still works). That option is off by default.
- `mdns-sd` sends multicast-only responses (no legacy unicast/QU support). Moonlight clients are fine with this, but it means `dig @224.0.0.251` style queries time out — test with a multicast listener instead.

## Testing

Verified locally (CachyOS, avahi running alongside):

- `0.0.0.0` advertises IPv4 only; `::` advertises dual-stack.
- No avahi conflicts or hostname renames in the journal while both share port 5353.
- Goodbye packets on SIGINT — the service vanishes from `avahi-browse` immediately.
- The responder answers raw multicast PTR queries for `_nvstream._tcp.local.`.