### PR TITLE
fix: bench hanging forever when no frames arrive before the duration deadline

### DIFF
--- a/moonshine-tools/src/bin/bench.rs
+++ b/moonshine-tools/src/bin/bench.rs
@@ -386,7 +386,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 				break;
 			},
 			_ = tokio::time::sleep(duration_remaining) => {
-				if duration_remaining.as_secs() > 0 {
+				if duration_deadline.is_some_and(|d| Instant::now() >= d) {
 					tracing::info!("Duration reached, stopping...");
 					break;
 				}


### PR DESCRIPTION
If the app never delivers a frame, the duration timeout's `duration_remaining.as_secs() > 0` guard stops passing once the remaining time drifts below a second, and the bench spins on a zero-length sleep forever instead of exiting. Checking the clock against the deadline directly makes it always stop at `--duration`.

This was mainly just as a result of a hang I had randomly that confused me while using moonshine-bench (which is very cool btw).