### PR TITLE
fix: use platform-agnostic c_char type instead of i8

### DIFF
--- a/moonshine-wsi/src/device.rs
+++ b/moonshine-wsi/src/device.rs
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn create_device(
 
 	// Inject VK_EXT_swapchain_maintenance1 if not already enabled.
 	let create_info = &*p_create_info;
-	let mut exts: Vec<*const i8> = std::slice::from_raw_parts(
+	let mut exts: Vec<*const std::ffi::c_char> = std::slice::from_raw_parts(
 		create_info.pp_enabled_extension_names,
 		create_info.enabled_extension_count as usize,
 	)
@@ -128,11 +128,11 @@ unsafe fn build_device_dispatch(
 ) -> DeviceDispatch {
 	macro_rules! load {
 		($name:literal) => {{
-			let pfn = next_get_device_proc_addr(device, concat!($name, "\0").as_ptr() as *const i8);
+			let pfn = next_get_device_proc_addr(device, concat!($name, "\0").as_ptr() as *const std::ffi::c_char);
 			std::mem::transmute(pfn.expect(concat!("failed to load ", $name)))
 		}};
 		(opt: $name:literal) => {{
-			let pfn = next_get_device_proc_addr(device, concat!($name, "\0").as_ptr() as *const i8);
+			let pfn = next_get_device_proc_addr(device, concat!($name, "\0").as_ptr() as *const std::ffi::c_char);
 			pfn.map(|p| std::mem::transmute(p))
 		}};
 	}

--- a/moonshine-wsi/src/dispatch.rs
+++ b/moonshine-wsi/src/dispatch.rs
@@ -41,7 +41,7 @@ pub type PFN_vkGetDeviceProcAddr = unsafe extern "C" fn(VkDevice, *const std::ff
 ///
 /// # Safety
 /// Each non-null pointer in `exts` must point to a valid null-terminated C string.
-pub unsafe fn has_extension(exts: &[*const i8], name: &std::ffi::CStr) -> bool {
+pub unsafe fn has_extension(exts: &[*const std::ffi::c_char], name: &std::ffi::CStr) -> bool {
 	exts.iter()
 		.any(|&p| !p.is_null() && std::ffi::CStr::from_ptr(p) == name)
 }

--- a/moonshine-wsi/src/instance.rs
+++ b/moonshine-wsi/src/instance.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn create_instance(
 	// Only inject the extra WSI extensions when active.  In the degraded path
 	// the application's original create-info is passed through unchanged.
 	let create_info = &*p_create_info;
-	let mut exts: Vec<*const i8> = std::slice::from_raw_parts(
+	let mut exts: Vec<*const std::ffi::c_char> = std::slice::from_raw_parts(
 		create_info.pp_enabled_extension_names,
 		create_info.enabled_extension_count as usize,
 	)
@@ -222,11 +222,11 @@ unsafe fn build_instance_dispatch(
 ) -> InstanceDispatch {
 	macro_rules! load {
 		($name:literal) => {{
-			let pfn = next_get_proc_addr(instance, concat!($name, "\0").as_ptr() as *const i8);
+			let pfn = next_get_proc_addr(instance, concat!($name, "\0").as_ptr() as *const std::ffi::c_char);
 			std::mem::transmute(pfn.expect(concat!("failed to load ", $name)))
 		}};
 		(opt: $name:literal) => {{
-			let pfn = next_get_proc_addr(instance, concat!($name, "\0").as_ptr() as *const i8);
+			let pfn = next_get_proc_addr(instance, concat!($name, "\0").as_ptr() as *const std::ffi::c_char);
 			pfn.map(|f| std::mem::transmute(f))
 		}};
 	}

--- a/moonshine-wsi/src/surface.rs
+++ b/moonshine-wsi/src/surface.rs
@@ -397,10 +397,10 @@ static LAYER_EXTENSIONS: &[ash::vk::ExtensionProperties] = &[
 
 /// Convert a byte-string literal to a fixed-size `c_char` array at compile time.
 const fn ext_name(name: &[u8]) -> [std::ffi::c_char; 256] {
-	let mut buf = [0i8; 256];
+	let mut buf = [0 as std::ffi::c_char; 256];
 	let mut i = 0;
 	while i < name.len() && i < 255 {
-		buf[i] = name[i] as i8;
+		buf[i] = name[i] as std::ffi::c_char;
 		i += 1;
 	}
 	buf
@@ -726,7 +726,7 @@ mod tests {
 	#[test]
 	fn ext_name_zero_padded() {
 		let name = ext_name(b"X\0");
-		assert_eq!(name[0], b'X' as i8);
+		assert_eq!(name[0], b'X' as std::ffi::c_char);
 		assert_eq!(name[1], 0);
 		assert_eq!(name[255], 0);
 	}


### PR DESCRIPTION
On some platforms (notably ARM), char is unsigned rather than signed, so the build would fail due to use of i8. The FFI type alias works everywhere.