### PR TITLE
fix: subscribe to systemd signals before waiting on job/unit events

### DIFF
--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -86,6 +86,18 @@ const ACTIVE_STATE_PROPERTY: &str = "ActiveState";
 const STOP_JOB_TIMEOUT: Duration = Duration::from_secs(2);
 const UNIT_REMOVED_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// systemd only emits JobRemoved/UnitRemoved/PropertiesChanged bus signals to
+/// connections that have called org.freedesktop.systemd1.Manager.Subscribe().
+/// Without it, waiting for those signals only works when some *other* client
+/// on the user bus happens to hold a subscription. Call this once for every
+/// new session bus connection, before waiting on any systemd signals.
+async fn subscribe_to_systemd_signals(conn: &Connection) -> Result<(), ()> {
+	conn.call_method(Some(SYSTEMD_BUS), SYSTEMD_PATH, Some(SYSTEMD_MANAGER), "Subscribe", &())
+		.await
+		.map_err(|e| tracing::error!("Failed to subscribe to systemd signals: {e}"))?;
+	Ok(())
+}
+
 #[derive(Clone)]
 pub(crate) struct LaunchOptions<'a> {
 	pub unit_name: &'a str,
@@ -138,6 +150,7 @@ impl Application {
 		let conn = Connection::session()
 			.await
 			.map_err(|e| tracing::error!("Failed to connect to session bus: {e}"))?;
+		subscribe_to_systemd_signals(&conn).await?;
 
 		// Stop any leftover unit from a previous session.
 		let _ = stop_unit(&conn, &context.unit_name).await;
@@ -353,6 +366,7 @@ async fn stop_unit_owned(unit_name: String) -> Result<(), ()> {
 	let conn = Connection::session().await.map_err(|e| {
 		tracing::error!("Failed to connect to session bus: {e}");
 	})?;
+	subscribe_to_systemd_signals(&conn).await?;
 	stop_unit(&conn, &unit_name).await
 }
 


### PR DESCRIPTION
## The bug

Moonshine launches and stops streamed applications as transient systemd user units over D-Bus, then waits for `JobRemoved` / `UnitRemoved` / `PropertiesChanged` signals to learn the outcome. Receiving those signals takes two independent steps:

1. installing a match rule on the bus so matching signals get routed to you (zbus does this automatically), and
2. telling systemd to emit them at all — systemd deliberately does **not** broadcast job/unit-state signals unless at least one client has called `org.freedesktop.systemd1.Manager.Subscribe()` (see the "Signals" note in the [systemd D-Bus API docs](https://www.freedesktop.org/wiki/Software/systemd/dbus/)).

Moonshine does step 1 but never step 2, so it waits for signals systemd never sends.

The bug hides easily because subscription state is effectively global per user manager: if *any* other connection on the user bus holds a subscription (a running `systemctl --user`, a desktop session daemon, ...), systemd broadcasts the signals and moonshine's match rules receive them. On a headless, linger-only host — exactly the setup the README advertises — there is no other subscriber, and every launch behaves the same way: the application starts fine, but the wait for `JobRemoved` times out, moonshine concludes the launch failed and tears the session down (black screen / "application exited" in Moonlight while the game may actually be running). Stop waits time out the same way.

## The fix

Call `Subscribe()` on the connection at the top of the three wait paths (`start_transient_service`, `wait_for_unit_active`, `stop_unit`):

- placed **before** the `StartTransientUnit`/`StopUnit` method calls so no signal can fire in the gap;
- result ignored, because repeat calls on an already-subscribed connection just return `org.freedesktop.systemd1.AlreadySubscribed`, making the call idempotent without tracking state.

## Verified

Running this patch on a headless NixOS host (user session alive only via `loginctl enable-linger`, no other bus clients): without the patch every launch times out after `launch_timeout_secs` and the session is torn down; with it, launch and stop waits complete immediately.
