### PR TITLE
Add Fedora RPM packaging

### DIFF
--- a/dist/fedora/README.md
+++ b/dist/fedora/README.md
@@ -1,0 +1,61 @@
+# Fedora packaging
+
+RPM packaging for Moonshine. Produces:
+
+- `moonshine` — the streaming server, start script, systemd unit
+  (`moonshine@.service`), udev rules, modules-load config, and the
+  `VkLayer_moonshine_wsi` Vulkan implicit layer.
+- `moonshine-tools` — the `moonshine-bench` encoding-pipeline benchmark.
+
+## Building locally
+
+Install the build dependencies:
+
+```sh
+sudo dnf install rust cargo gcc gcc-c++ clang cmake make perl git \
+    libevdev-devel pulseaudio-libs-devel opus-devel libxkbcommon-devel \
+    wayland-devel mesa-libgbm-devel mesa-libEGL-devel libdrm-devel \
+    libshaderc-devel vulkan-headers vulkan-loader-devel \
+    rpm-build rpmdevtools
+```
+
+Generate the source tarballs (this runs `cargo vendor`, so it needs network
+access — the RPM build itself is fully offline afterwards):
+
+```sh
+rpmdev-setuptree
+./dist/fedora/make-source-tarballs.sh
+```
+
+Build the RPMs:
+
+```sh
+rpmbuild -ba dist/fedora/moonshine.spec
+```
+
+The packages land in `~/rpmbuild/RPMS/$(uname -m)/`.
+
+## Installing
+
+```sh
+sudo dnf install ~/rpmbuild/RPMS/$(uname -m)/moonshine-*.rpm
+sudo loginctl enable-linger $USER   # optional, for streaming while logged out
+sudo systemctl enable --now moonshine@$USER
+```
+
+The service reads its configuration from
+`/home/<user>/.config/moonshine/config.toml` (created on first start).
+
+## Notes
+
+- **Vendored dependencies**: the project pins git forks of `smithay`,
+  `pixelforge`, `ash`, and `inputtino`, so dependencies are vendored into a
+  tarball (`Source1`) rather than resolved at build time. This also means the
+  package is not eligible for the official Fedora repos as-is (Fedora requires
+  crates.io releases); it is suitable for COPR or local use.
+- **COPR**: build the two tarballs locally with `make-source-tarballs.sh`,
+  then upload the SRPM produced by
+  `rpmbuild -bs dist/fedora/moonshine.spec`.
+- **Tests**: `%check` is disabled by default because some unit tests exercise
+  GPU/compositor code paths unavailable in a chroot. Enable with
+  `rpmbuild --with check`.

--- a/dist/fedora/make-source-tarballs.sh
+++ b/dist/fedora/make-source-tarballs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Generate the two source tarballs referenced by moonshine.spec:
+#
+#   moonshine-<version>.tar.gz         pristine source (git archive of HEAD)
+#   moonshine-<version>-vendor.tar.xz  vendored Rust dependencies + cargo config
+#
+# The vendor tarball is required for an offline RPM build because the project
+# pins git forks (smithay, pixelforge, ash, inputtino) that cargo cannot
+# resolve from crates.io inside a build chroot.
+#
+# Usage: make-source-tarballs.sh [output-dir]
+#   output-dir defaults to ~/rpmbuild/SOURCES (created if missing).
+
+set -euo pipefail
+
+repo_root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+version=$(sed -n 's/^version = "\(.*\)"/\1/p' "$repo_root/Cargo.toml" | head -n1)
+outdir=${1:-"$HOME/rpmbuild/SOURCES"}
+mkdir -p "$outdir"
+outdir=$(cd "$outdir" && pwd)
+
+echo "Packaging moonshine $version from $repo_root"
+
+# 1. Pristine source tarball from git.
+git -C "$repo_root" archive --format=tar.gz --prefix="moonshine-$version/" \
+    -o "$outdir/moonshine-$version.tar.gz" HEAD
+echo "Wrote $outdir/moonshine-$version.tar.gz"
+
+# 2. Vendor tarball. Vendor from an extracted copy of the source tarball so the
+#    result matches exactly what rpmbuild will unpack.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+tar -xzf "$outdir/moonshine-$version.tar.gz" -C "$tmpdir"
+cd "$tmpdir/moonshine-$version"
+
+mkdir -p .cargo
+# `cargo vendor` prints the [source] replacement config needed to use the
+# vendor directory (including entries for each git dependency) — capture it.
+cargo vendor --locked vendor > .cargo/config.toml
+
+# --- inputtino-sys fixup -----------------------------------------------------
+# inputtino-sys lives at bindings/rust/inputtino-sys inside the inputtino git
+# repo and its build.rs compiles the C library from "../../../" (the repo
+# root). `cargo vendor` only ships the crate subdirectory, so the C sources are
+# missing from the vendor tree. Graft the full repo (from cargo's git
+# checkout, populated by `cargo vendor` above) into the vendored crate and
+# point build.rs at it. Also drop the `-lc++` link line: the RPM build
+# compiles inputtino with g++, so libstdc++ is the right (and only needed)
+# C++ runtime on Fedora.
+inputtino_rev=$(sed -n 's|.*git+https://github.com/games-on-whales/inputtino#\([0-9a-f]*\)".*|\1|p' Cargo.lock | head -n1)
+checkout=$(find "$HOME/.cargo/git/checkouts" -maxdepth 2 -type d -name "${inputtino_rev:0:7}*" -path "*inputtino*" | head -n1)
+if [ -z "$checkout" ]; then
+    echo "ERROR: inputtino git checkout for rev $inputtino_rev not found in ~/.cargo/git/checkouts" >&2
+    exit 1
+fi
+cp -a "$checkout" vendor/inputtino-sys/native
+rm -rf vendor/inputtino-sys/native/.git
+sed -i 's|PathBuf::from("../../../")|PathBuf::from("native")|' vendor/inputtino-sys/build.rs
+sed -i '/rustc-link-lib=c++/d' vendor/inputtino-sys/build.rs
+# The crate content changed; blank the per-file checksums so cargo accepts it.
+python3 -c "
+import json
+p = 'vendor/inputtino-sys/.cargo-checksum.json'
+d = json.load(open(p))
+d['files'] = {}
+json.dump(d, open(p, 'w'))
+"
+# -----------------------------------------------------------------------------
+
+tar -cJf "$outdir/moonshine-$version-vendor.tar.xz" vendor .cargo/config.toml
+echo "Wrote $outdir/moonshine-$version-vendor.tar.xz"

--- a/dist/fedora/moonshine.spec
+++ b/dist/fedora/moonshine.spec
@@ -1,0 +1,127 @@
+# Build-time tests are disabled by default: some unit tests exercise
+# GPU/compositor paths that are not available in a build chroot.
+# Enable with: rpmbuild --with check ...
+%bcond_with check
+
+Name:           moonshine
+Version:        0.12.0
+Release:        1%{?dist}
+Summary:        Game streaming host for Moonlight clients
+
+License:        BSD-2-Clause
+URL:            https://github.com/hgaiser/moonshine
+# Created with dist/fedora/make-source-tarballs.sh:
+Source0:        %{name}-%{version}.tar.gz
+# Vendored Rust dependencies (vendor/ + .cargo/config.toml). Required because
+# the project pins git forks of smithay, pixelforge, ash and inputtino, which
+# cannot be resolved offline from crates.io.
+Source1:        %{name}-%{version}-vendor.tar.xz
+
+ExclusiveArch:  x86_64 aarch64
+
+BuildRequires:  cargo
+BuildRequires:  rust
+BuildRequires:  clang
+BuildRequires:  cmake
+BuildRequires:  gcc
+BuildRequires:  gcc-c++
+BuildRequires:  make
+# aws-lc-sys (pulled in via aws-lc-rs) needs perl to build.
+BuildRequires:  perl
+BuildRequires:  pkgconfig(egl)
+BuildRequires:  pkgconfig(gbm)
+BuildRequires:  pkgconfig(libdrm)
+BuildRequires:  pkgconfig(libevdev)
+BuildRequires:  pkgconfig(libpulse)
+BuildRequires:  pkgconfig(opus)
+BuildRequires:  pkgconfig(wayland-client)
+BuildRequires:  pkgconfig(wayland-server)
+BuildRequires:  pkgconfig(xkbcommon)
+BuildRequires:  libshaderc-devel
+BuildRequires:  vulkan-headers
+BuildRequires:  vulkan-loader-devel
+BuildRequires:  systemd-rpm-macros
+
+# The compositor spawns Xwayland for X11 clients.
+Requires:       xorg-x11-server-Xwayland
+Requires:       vulkan-loader
+# Applications are launched via systemd-run --user.
+Requires:       systemd
+
+%description
+Moonshine lets you stream games from your PC to any device running Moonlight.
+Each stream runs in its own isolated headless compositor, separate from your
+desktop environment, so no monitor or active desktop session is required.
+Video is encoded on the GPU (H.264, H.265, AV1) with HDR support, audio is
+streamed with low-latency Opus, and full mouse/keyboard/gamepad input is
+forwarded to the host.
+
+%package tools
+Summary:        Benchmarking utilities for Moonshine
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description tools
+Utilities for testing and benchmarking Moonshine, including moonshine-bench,
+which benchmarks the video encoding pipeline by running an application inside
+a headless compositor and collecting per-frame timing statistics.
+
+%prep
+%autosetup
+# Unpack vendored dependencies (vendor/ and .cargo/config.toml).
+tar -xJf %{SOURCE1}
+
+%build
+export RUSTFLAGS="%{?build_rustflags}"
+cargo build --release --offline --workspace
+
+%install
+install -Dm755 target/release/moonshine %{buildroot}%{_bindir}/moonshine
+install -Dm755 target/release/moonshine-bench %{buildroot}%{_bindir}/moonshine-bench
+install -Dm755 dist/start-moonshine.sh %{buildroot}%{_bindir}/start-moonshine.sh
+
+# Vulkan implicit layer that routes game frames to the Moonshine compositor.
+install -Dm755 target/release/libmoonshine_wsi.so \
+    %{buildroot}%{_libdir}/moonshine/vulkan-layers/libmoonshine_wsi.so
+install -Dm644 dist/VkLayer_moonshine_wsi.json \
+    %{buildroot}%{_datadir}/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+# The manifest ships with a hardcoded /usr/lib path; point it at %%{_libdir}.
+sed -i 's|/usr/lib/moonshine/vulkan-layers|%{_libdir}/moonshine/vulkan-layers|' \
+    %{buildroot}%{_datadir}/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+
+install -Dm644 dist/moonshine@.service %{buildroot}%{_unitdir}/moonshine@.service
+install -Dm644 dist/60-moonshine.rules %{buildroot}%{_udevrulesdir}/60-moonshine.rules
+install -Dm644 dist/moonshine-modules.conf %{buildroot}%{_modulesloaddir}/moonshine.conf
+
+%if %{with check}
+%check
+cargo test --release --offline --workspace
+%endif
+
+%post
+%systemd_post moonshine@.service
+
+%preun
+%systemd_preun moonshine@.service
+
+%postun
+%systemd_postun_with_restart moonshine@.service
+
+%files
+%license LICENSE
+%doc README.md CHANGELOG.md
+%{_bindir}/moonshine
+%{_bindir}/start-moonshine.sh
+%dir %{_libdir}/moonshine
+%dir %{_libdir}/moonshine/vulkan-layers
+%{_libdir}/moonshine/vulkan-layers/libmoonshine_wsi.so
+%{_datadir}/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+%{_unitdir}/moonshine@.service
+%{_udevrulesdir}/60-moonshine.rules
+%{_modulesloaddir}/moonshine.conf
+
+%files tools
+%{_bindir}/moonshine-bench
+
+%changelog
+* Mon Jul 20 2026 Alexander Kvartz <917344+akvartz@users.noreply.github.com> - 0.12.0-1
+- Initial Fedora package


### PR DESCRIPTION
Adds RPM packaging for Fedora under `dist/fedora/`, following the existing `dist/` convention:

- `moonshine.spec` — builds the workspace offline; produces a `moonshine` package (server, `start-moonshine.sh`, systemd unit, udev rules, modules-load config, and the WSI Vulkan layer with its manifest path rewritten for `%{_libdir}`) and a `moonshine-tools` subpackage with `moonshine-bench`.
- `make-source-tarballs.sh` — generates the pristine source tarball plus a `cargo vendor` tarball, needed because the pinned git dependencies (smithay, pixelforge, ash, inputtino) can't be fetched during an RPM build. Includes a fixup for `inputtino-sys`, whose build.rs expects the full inputtino repo two levels above the crate — the script grafts the C sources into the vendored crate.
- `README.md` — build and install instructions.

Verified end-to-end with `rpmbuild -ba` on Fedora 44 (x86_64): packages build, the binary runs, and the Vulkan layer manifest resolves correctly. Intended for COPR/local use rather than official Fedora repos, since Fedora's guidelines don't allow git-pinned dependencies.