### PR TITLE
build: add nix flake with package and NixOS module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 __pycache__/
+/result

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ To run Moonshine for your user:
    sudo systemctl enable --now moonshine@$USER
    ```
 
+### NixOS
+
+This repository is also a nix flake, providing a package and a NixOS module that sets up the service for you.
+See [nix/README.md](nix/README.md) for instructions.
+
 ### Source
 
 The following dependencies are required to build and run:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "Moonshine — stream games to Moonlight clients from a headless Linux host";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = f: lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      # For consumers who want `pkgs.moonshine` available everywhere
+      # (e.g. added next to a host in a NixOS flake's nixpkgs.overlays).
+      overlays.default = final: _prev: {
+        moonshine = final.callPackage ./nix/package.nix { };
+      };
+
+      packages = forAllSystems (pkgs: rec {
+        moonshine = pkgs.callPackage ./nix/package.nix { };
+        default = moonshine;
+      });
+
+      # NixOS service: `services.moonshine.*` (see nix/module.nix). The
+      # package defaults to this flake's build; no overlay required.
+      nixosModules = {
+        moonshine =
+          { pkgs, lib, ... }:
+          {
+            imports = [ ./nix/module.nix ];
+            services.moonshine.package =
+              lib.mkDefault
+                self.packages.${pkgs.stdenv.hostPlatform.system}.moonshine;
+          };
+        default = self.nixosModules.moonshine;
+      };
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.moonshine ];
+          # inputtino-sys's build.rs unconditionally links libc++. The package
+          # build strips that from the vendored crate (see nix/package.nix),
+          # but plain cargo in this shell builds the real inputtino checkout,
+          # so `cargo test`/`cargo build` need libc++ to link — same reason
+          # upstream's Arch build deps list libc++ next to gcc-libs.
+          buildInputs = [ pkgs.llvmPackages.libcxx ];
+          packages = with pkgs; [
+            rustfmt
+            clippy
+          ];
+        };
+      });
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,78 @@
+# Moonshine on NixOS ❄️
+
+This directory contains a [nix flake](https://wiki.nixos.org/wiki/Flakes) that builds Moonshine and provides a NixOS module for running it as a service.
+
+## What you get
+
+- **A package**: the `moonshine` binary, the moonshine-wsi Vulkan layer, and the udev rules, built from this repository.
+- **A NixOS module**: a `services.moonshine` service that takes care of everything from the [installation steps](../README.md#installation): lingering, kernel modules, device permissions, and the systemd service.
+- **A dev shell**: the full build environment for working on Moonshine.
+
+## Building
+
+```sh
+nix build github:hgaiser/moonshine
+./result/bin/moonshine --help
+```
+
+## Running as a service
+
+Add the flake to the inputs of your system flake:
+
+```nix
+inputs.moonshine.url = "github:hgaiser/moonshine";
+```
+
+Then import the module and enable the service in your configuration:
+
+```nix
+{ inputs, ... }:
+{
+  imports = [ inputs.moonshine.nixosModules.default ];
+
+  services.moonshine = {
+    enable = true;
+
+    # The user whose applications you want to stream.
+    user = "alice";
+    # Only needed when the user's uid is not declared in your
+    # configuration. Check with `id -u alice`.
+    uid = 1000;
+
+    # Opens the GameStream ports. Only do this on a LAN or VPN-facing
+    # firewall. See Security in the main README.
+    openFirewall = true;
+
+    # Everything from the Configuration section of the main README goes
+    # here, written as nix instead of TOML.
+    settings = {
+      application = [
+        {
+          title = "Steam";
+          command = [
+            "/run/current-system/sw/bin/steam"
+            "steam://open/bigpicture"
+          ];
+        }
+      ];
+    };
+  };
+}
+```
+
+After `nixos-rebuild switch` the service is running. There is no `systemctl enable` step, and user lingering is enabled automatically. Pair with a Moonlight client as usual via http://localhost:47989/pin .
+
+Settings you leave out fall back to Moonshine's defaults. Note that the default application list points at `/usr/bin/steam`, which doesn't exist on NixOS, so you will want to set `application` as shown above.
+
+## Development
+
+```sh
+nix develop
+cargo build
+```
+
+The shell contains the full build environment, plus `clippy` and `rustfmt` as used by CI.
+
+## Maintenance
+
+There is nothing here to keep up to date when dependencies change: the nix build derives everything from `Cargo.lock`. The one exception is a pinned hash for `ash` in [package.nix](package.nix). See the comment there.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,192 @@
+# NixOS module for the Moonshine game streaming server.
+#
+# Runs moonshine as a *system* service on behalf of a regular user (upstream's
+# moonshine@.service template, with start-moonshine.sh's env bootstrapping done
+# declaratively), NOT as a systemd user unit: nixos-rebuild switch only manages
+# the lifecycle of system units — user units merely get a daemon-reload — so as
+# a user unit every change (including a new config store path in ExecStart)
+# would need a manual `systemctl --user restart moonshine`. As a system unit
+# the switch restarts it automatically whenever the unit or config changes.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.moonshine;
+
+  settingsFormat = pkgs.formats.toml { };
+
+  # The store-managed source of truth, passed straight to the unit. That is
+  # safe because moonshine only ever *writes* a config when the given path
+  # doesn't exist; all mutable state lives elsewhere and stays out of the
+  # store: pairing state in ~/.local/share/moonshine/state.toml and the
+  # self-signed TLS cert/key at the $HOME paths in the webserver config
+  # ($HOME et al. are expanded by moonshine at runtime via shellexpand).
+  configFile = settingsFormat.generate "moonshine-config.toml" cfg.settings;
+
+  runtimeDir = "/run/user/${toString cfg.uid}";
+in
+{
+  options.services.moonshine = {
+    enable = lib.mkEnableOption "Moonshine, a game streaming server for Moonlight clients";
+
+    package = lib.mkPackageOption pkgs "moonshine" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      example = "alice";
+      description = ''
+        User to run moonshine as. Streamed applications are launched as
+        transient units inside this user's systemd instance, so it should be
+        the user whose Steam library / applications you want to stream.
+        Lingering is enabled for this user automatically.
+      '';
+    };
+
+    uid = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
+      default = config.users.users.${cfg.user}.uid or null;
+      defaultText = lib.literalExpression "config.users.users.<user>.uid";
+      example = 1000;
+      description = ''
+        Numeric uid of {option}`services.moonshine.user`, used to locate the
+        user's runtime dir (`/run/user/<uid>`) and session D-Bus socket, and
+        to order the service after `user@<uid>.service`. Only needs to be set
+        explicitly when the user's uid is allocated rather than declared
+        (check with `id -u <user>`).
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      example = lib.literalExpression ''
+        {
+          name = "Moonshine";
+          application = [
+            {
+              title = "Steam";
+              command = [ "/run/current-system/sw/bin/steam" "steam://open/bigpicture" ];
+            }
+          ];
+        }
+      '';
+      description = ''
+        Moonshine configuration, generated into a TOML file in the store and
+        passed to the daemon. Settings left out fall back to upstream's
+        defaults (note: the default application list points at
+        `/usr/bin/steam`, so you will want to at least set `application`).
+        See <https://github.com/hgaiser/moonshine> for the format.
+      '';
+    };
+
+    logFilter = lib.mkOption {
+      type = lib.types.str;
+      default = "moonshine=info";
+      example = "moonshine=info,moonshine_core::tls=error";
+      description = ''
+        Value for `MOONSHINE_LOG` (env_logger-style filter). The example
+        additionally silences the WARN logged for every dropped TLS probe —
+        a Moonlight client idling on its Computers screen polls the HTTPS
+        port every 5s, spamming "TLS handshake failed" into the journal.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Open the GameStream ports in the firewall: HTTP pairing/discovery,
+        HTTPS, and RTSP over TCP; video/control/audio over UDP. Port numbers
+        follow {option}`services.moonshine.settings` where set. Moonshine is
+        not designed for public networks — only enable this on a LAN or
+        VPN-facing firewall.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.uid != null;
+        message = ''
+          services.moonshine.uid could not be derived: users.users.${cfg.user}.uid
+          is not declared. Set services.moonshine.uid to `id -u ${cfg.user}`
+          (or declare a fixed uid for the user).
+        '';
+      }
+    ];
+
+    # Besides the binary, the package carries the Vulkan implicit-layer
+    # manifest (share/vulkan/implicit_layer.d) that the loader must be able
+    # to find; it only engages for apps moonshine launches
+    # (ENABLE_MOONSHINE_WSI=1), so it is inert for everything else.
+    environment.systemPackages = [ cfg.package ];
+
+    # Grants the `input` group + active-seat ACLs on /dev/uinput and
+    # /dev/uhid, which inputtino uses to create the virtual
+    # gamepad/keyboard/mouse.
+    services.udev.packages = [ cfg.package ];
+
+    # Virtual input backends used by inputtino (upstream ships this as a
+    # modules-load.d drop-in).
+    boot.kernelModules = [
+      "uinput"
+      "uhid"
+    ];
+
+    # Keep the user's systemd instance and its session D-Bus alive from boot,
+    # independent of any graphical login — moonshine needs both. This is what
+    # upstream's `loginctl enable-linger` install step does.
+    users.users.${cfg.user}.linger = true;
+
+    systemd.services.moonshine = {
+      description = "Moonshine game streaming server (Moonlight protocol)";
+      wantedBy = [ "multi-user.target" ];
+      # The user manager owns the runtime dir, session bus, and the transient
+      # units moonshine launches apps as (moonshine-session.service).
+      requires = [ "user@${toString cfg.uid}.service" ];
+      after = [ "user@${toString cfg.uid}.service" ];
+      # The compositor spawns Xwayland (X11 games, i.e. most of Steam, run
+      # under it) from the unit's PATH.
+      path = [ pkgs.xwayland ];
+      environment = {
+        MOONSHINE_LOG = cfg.logFilter;
+        # What the user manager would have provided, set by hand as in
+        # upstream's start-moonshine.sh: the Wayland socket goes in the
+        # runtime dir, and apps are launched via the user manager's D-Bus API.
+        XDG_RUNTIME_DIR = runtimeDir;
+        DBUS_SESSION_BUS_ADDRESS = "unix:path=${runtimeDir}/bus";
+      };
+      serviceConfig = {
+        User = cfg.user;
+        # /dev/uinput and /dev/uhid are input-group 0660 via the package's
+        # udev rules (a system unit can grant supplementary groups directly,
+        # so no extraGroups on the user).
+        SupplementaryGroups = [
+          "input"
+          "video"
+        ];
+        ExecStart = "${lib.getExe cfg.package} ${configFile}";
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        (cfg.settings.webserver.port_https or 47984)
+        (cfg.settings.webserver.port or 47989)
+        (cfg.settings.stream.port or 48010)
+      ];
+      allowedUDPPorts = [
+        (cfg.settings.stream.video.port or 47998)
+        (cfg.settings.stream.control.port or 47999)
+        (cfg.settings.stream.audio.port or 48000)
+      ];
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,169 @@
+{
+  lib,
+  rustPlatform,
+  addDriverRunpath,
+  cmake,
+  pkg-config,
+  libdrm,
+  libevdev,
+  libpulseaudio,
+  libxkbcommon,
+  libgbm,
+  libopus,
+  vulkan-loader,
+  wayland,
+  libglvnd,
+}:
+
+let
+  version = (lib.importTOML ../Cargo.toml).workspace.package.version;
+
+  # Only what the build actually consumes, so touching flake.nix, the README,
+  # or CI config doesn't rebuild the world. assets/ is required: the webserver
+  # embeds assets/pin.html via include_bytes!.
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../src
+      ../moonshine-core
+      ../moonshine-tools
+      ../moonshine-wsi
+      ../assets
+      ../dist
+    ];
+  };
+
+  # inputtino-sys's build.rs compiles the C++ libinputtino with cmake from
+  # `../../../` — the root of the inputtino git repo, of which the vendored
+  # crate is only the bindings/rust/inputtino-sys subdirectory. Plain cargo
+  # keeps full git checkouts so that works everywhere else, but nix vendoring
+  # extracts just the crate, so the path escapes the vendor tree and cmake
+  # finds no CMakeLists.txt. Graft the full repo into the vendored crate (see
+  # postPatch) and aim build.rs at it. The rev is parsed out of Cargo.lock so
+  # dependency bumps upstream are picked up without touching the nix code.
+  inputtinoLockEntry =
+    lib.findFirst (p: p.name == "inputtino-sys")
+      (throw "inputtino-sys not found in Cargo.lock; drop the graft in nix/package.nix")
+      (lib.importTOML ../Cargo.lock).package;
+  # e.g. "git+https://github.com/games-on-whales/inputtino#<rev>"
+  inputtinoMatch = builtins.match "git\\+([^?#]+)(\\?[^#]*)?#(.+)" inputtinoLockEntry.source;
+  inputtinoRepo = builtins.fetchGit {
+    url = builtins.elemAt inputtinoMatch 0;
+    rev = builtins.elemAt inputtinoMatch 2;
+    allRefs = true;
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "moonshine";
+  inherit version src;
+
+  # No vendor hash to maintain: crates.io checksums come straight from
+  # Cargo.lock, and git dependencies are fetched at eval time by the rev the
+  # lockfile pins (allowBuiltinFetchGit), so the lockfile the maintainers
+  # already keep up to date is the single source of truth.
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    allowBuiltinFetchGit = true;
+    outputHashes = {
+      # Exception: ash's pinned rev sits on an unmerged PR branch, unreachable
+      # from any ref, so the builtin git fetcher (which only fetches refs)
+      # cannot get it and this fixed hash is needed. If the ash pin changes
+      # this fails loudly: a rev bump prints the correct new hash in the
+      # mismatch error, and once the pin moves to a rev on a normal branch or
+      # tag this entry can simply be deleted.
+      "ash-0.38.0+1.4.329" = "sha256-apzc//AZqS3F4e4Epm3Dl20ZkkMKUvLjyxv7ZwJh1Jw=";
+    };
+  };
+
+  # The inputtino graft described above. The cargo setup hook has already
+  # copied the vendor dir into the build tree as $cargoDepsCopy (writable,
+  # symlinks dereferenced); this attr runs before the hook that unsets it.
+  # The crate's .cargo-checksum.json lists no files, so cargo accepts the
+  # edits. While in there, also drop the unconditional `-lc++` (LLVM libc++)
+  # link — redundant next to `-lstdc++` and absent from a gcc stdenv.
+  postPatch = ''
+    sysdir=$(echo "$cargoDepsCopy"/inputtino-sys-*)
+    cp -r ${inputtinoRepo} "$sysdir/inputtino-repo"
+    substituteInPlace "$sysdir/build.rs" \
+      --replace-fail '"../../../"' '"inputtino-repo"' \
+      --replace-fail 'println!("cargo:rustc-link-lib=c++");' ""
+  '';
+
+  # A bare `cargo build` only builds the root package; the workspace also
+  # produces libmoonshine_wsi.so, the Vulkan implicit layer that routes a
+  # game's swapchain frames into moonshine's headless compositor.
+  cargoBuildFlags = [ "--workspace" ];
+
+  nativeBuildInputs = [
+    addDriverRunpath # see postFixup
+    cmake # inputtino-sys and aws-lc-sys build their C/C++ via cmake
+    pkg-config
+    rustPlatform.bindgenHook # inputtino-sys generates its bindings at build time
+  ];
+  # cmake above is only for vendored crates' build scripts; the workspace
+  # itself is plain cargo, so don't let cmake's setup hook take over
+  # configurePhase.
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    libdrm
+    libevdev
+    libpulseaudio
+    libxkbcommon
+    libgbm # smithay's GPU buffer allocation (split out of mesa in nixpkgs)
+    libopus
+    vulkan-loader
+    wayland
+  ];
+
+  # The tests exercise the compositor/encoder paths and expect devices
+  # (GPU, uinput) that the build sandbox does not have.
+  doCheck = false;
+
+  postInstall = ''
+    # cargoInstallHook has placed the moonshine binary in $out/bin and the
+    # moonshine-wsi cdylib in $out/lib; fail loudly if the layer is missing
+    # (e.g. --workspace stopped covering it).
+    test -f $out/lib/libmoonshine_wsi.so
+
+    # Vulkan implicit-layer manifest, pointed at the store path.
+    install -Dm644 dist/VkLayer_moonshine_wsi.json \
+      $out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+    substituteInPlace $out/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json \
+      --replace-fail /usr/lib/moonshine/vulkan-layers/libmoonshine_wsi.so \
+      $out/lib/libmoonshine_wsi.so
+
+    # Input-group access + active-seat ACLs for /dev/uinput and /dev/uhid,
+    # picked up by services.udev.packages.
+    install -Dm644 dist/60-moonshine.rules $out/lib/udev/rules.d/60-moonshine.rules
+  '';
+
+  postFixup = ''
+    # NVIDIA (and GPU generally): pixelforge opens libvulkan.so.1 with
+    # dlopen (ash's "loaded" feature) and smithay's GL renderer does the
+    # same for libEGL, so neither lands in DT_NEEDED and the automatic
+    # buildInputs RUNPATH doesn't cover them. Add the Vulkan loader + glvnd
+    # dispatch explicitly, and /run/opengl-driver/lib (addDriverRunpath) so
+    # the NVIDIA userspace driver and its Vulkan ICD resolve at runtime.
+    patchelf --add-rpath ${
+      lib.makeLibraryPath [
+        vulkan-loader
+        libglvnd
+      ]
+    } $out/bin/moonshine
+    addDriverRunpath $out/bin/moonshine
+  '';
+
+  meta = {
+    description = "Streaming server for Moonlight clients, written in Rust";
+    homepage = "https://github.com/hgaiser/moonshine";
+    license = lib.licenses.bsd2;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "moonshine";
+  };
+}


### PR DESCRIPTION
This adds a nix flake so that NixOS users can build and run Moonshine straight from this repository, plus a `services.moonshine` NixOS module that sets up everything the installation section of the README describes: the systemd service, user lingering, the `uinput`/`uhid` kernel modules, udev rules, and (optionally) the firewall ports. There is also a dev shell with the full build environment, including the `clippy` and `rustfmt` setup CI uses.

Everything lives in `flake.nix`, `flake.lock`, and the `nix/` directory. The only touch on existing files is a short NixOS subsection in the README linking to [nix/README.md](https://github.com/hgaiser/moonshine/blob/main/nix/README.md), which documents usage in the same style as the rest of the README. Nothing about the existing build or CI changes.

## Why in this repo instead of a fork

Flakes are consumed by repository URL, so having it here means `nix build github:hgaiser/moonshine` and the module import just work for everyone, without anyone maintaining a separate packaging repo that drifts out of date.

## Maintenance cost if you don't use nix

This was written so it should be none in practice:

- The nix build derives all dependency vendoring from `Cargo.lock`. Bumping, adding, or removing crates (including the git dependencies) needs no changes on the nix side.
- The one exception is a pinned hash for `ash`, because its locked rev sits on an unmerged branch that ref-based fetchers cannot reach. If the ash pin ever changes, the nix build fails loudly and prints the correct new hash (and once ash points at a normal release, the entry just gets deleted). The comment in `nix/package.nix` explains this.
- New system library dependencies (new `-sys` crates) would need a one-line addition, which nix users will notice and can PR.
- `flake.lock` pins nixpkgs and only needs occasional bumping, which again nix users can PR.

Verified with a full `nix build` on x86_64-linux, and the module is running Moonshine on a headless NixOS host streaming Steam.
