### PR TITLE
fix: drop nonexistent security.polkit.extraPolicies from NixOS module

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -133,13 +133,12 @@ in
 
     # Group that opt-in users join so the suspend-inhibit polkit rule
     # (shipped in the package) lets Moonshine hold a block-type sleep
-    # inhibitor. See TIPS.md.
+    # inhibitor. See TIPS.md. The rule itself needs no wiring here: nixpkgs
+    # builds polkit with --datadir=/run/current-system/sw/share and its module
+    # links /share/polkit-1 into the system path, so
+    # share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules is picked up
+    # from environment.systemPackages above.
     users.groups.moonshine = { };
-
-    # Allow the 'moonshine' group to acquire a block-type sleep inhibitor.
-    security.polkit.extraPolicies = [
-      "${cfg.package}/share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules"
-    ];
 
     # Virtual input backends used by inputtino (upstream ships this as a
     # modules-load.d drop-in).


### PR DESCRIPTION
`security.polkit.extraPolicies` isn't a nixpkgs option, so any NixOS config importing the module fails to evaluate:

```
error: The option `security.polkit.extraPolicies' does not exist.
Did you mean `security.polkit.extraConfig', `security.polkit.extraArgs' or `security.polkit.enable'?
```

It slipped through because I have a compat shim in my own dotfiles that declares the option, so it evaluated on my machine and nowhere else.

`extraConfig` isn't a swap for it, that takes polkit JS concatenated into `10-nixos.rules`, not rule file paths. Nothing needs to replace it: nixpkgs builds polkit with `--datadir=/run/current-system/sw/share` and its module sets `environment.pathsToLink = [ "/share/polkit-1" ]`, so the package's rule already reaches the system path through `environment.systemPackages = [ cfg.package ]`, which the module sets.

Verified on NixOS 26.11: a minimal config importing the module evaluates cleanly, and `/run/current-system/sw/share/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules` resolves to the moonshine store path.

Closes #140.
