### PR TITLE
fix: preserve SteamOS configuration across atomic updates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,7 +65,8 @@ jobs:
         cp ./target/release/libmoonshine_wsi.so "$STAGE/lib/moonshine/vulkan-layers/"
         cp ./dist/start-moonshine.sh ./dist/60-moonshine.rules ./dist/50-moonshine-inhibit-sleep.rules \
            ./dist/moonshine-modules.conf ./dist/moonshine-sysusers.conf \
-           ./dist/moonshine@.service ./dist/VkLayer_moonshine_wsi.json "$STAGE/share/moonshine/"
+           ./dist/moonshine@.service ./dist/VkLayer_moonshine_wsi.json \
+           ./dist/moonshine-atomic-update.conf "$STAGE/share/moonshine/"
         cp ./dist/moonshine-install.sh "$STAGE/bin/"
         cp README.md LICENSE "$STAGE/"
         tar --zstd -cf "./moonshine-${{ steps.tag.outputs.tag }}-linux-amd64.tar.zst" \

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use the installer script:
 curl -fsSL https://github.com/hgaiser/moonshine/releases/latest/download/moonshine-install.sh | bash
 ```
 
-This deploys moonshine to `/opt/moonshine/` and configuration drop-ins to `/etc/`.
+This deploys moonshine to `/opt/moonshine/` and configuration drop-ins to `/etc/`. The installer registers these files with SteamOS so they persist across atomic updates.
 
 ### Enable the service
 

--- a/dist/moonshine-atomic-update.conf
+++ b/dist/moonshine-atomic-update.conf
@@ -1,0 +1,9 @@
+## Moonshine files installed into /etc by moonshine-install.sh
+/etc/systemd/system/moonshine@.service
+/etc/systemd/system/default.target.wants/moonshine@*.service
+/etc/udev/rules.d/60-moonshine.rules
+/etc/modules-load.d/moonshine.conf
+/etc/sysusers.d/moonshine.conf
+/etc/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+/etc/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules
+/etc/profile.d/moonshine.sh

--- a/dist/moonshine-install.sh
+++ b/dist/moonshine-install.sh
@@ -154,6 +154,7 @@ if [[ "$UNINSTALL" == "true" ]]; then
   sudo rm -f /etc/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
   sudo rm -f /etc/polkit-1/rules.d/50-moonshine-inhibit-sleep.rules
   sudo rm -f /etc/profile.d/moonshine.sh
+  sudo rm -f /etc/atomic-update.conf.d/moonshine.conf
   sudo systemctl daemon-reload || true
   sudo udevadm control --reload || true
 
@@ -281,6 +282,9 @@ CMDS=(
 
   # Create profile.d for PATH
   "echo 'export PATH=\"\${PATH}:${MOONSHINE_HOME}/bin\"' > /etc/profile.d/moonshine.sh"
+
+  # Preserve /etc integration across SteamOS atomic updates
+  "if [[ -d /etc/atomic-update.conf.d ]]; then cp '${S}/share/moonshine/moonshine-atomic-update.conf' /etc/atomic-update.conf.d/moonshine.conf; fi"
 
   # Reload systemd
   "systemctl daemon-reload"


### PR DESCRIPTION
Hey I found this after some investigation regarding immutability of SteamOS and how it handles upgrades. I did most of the investigation with pi + gpt 5.6 for full disclosure. But I think I found a problem with the current install script. According to AI:

Moonshine's [installer deployment change](https://github.com/hgaiser/moonshine/commit/421e3ff87ecb549a008f9b05836f9c9ff1a5d29f) moved the portable installation to `/opt/moonshine` and its system integration to `/etc`, as seen in the [v0.14.5 installer](https://github.com/hgaiser/moonshine/blob/v0.14.5/dist/moonshine-install.sh). `/opt` persists across SteamOS atomic updates, but arbitrary changes under `/etc` do not.

The systemd unit is covered by SteamOS's current default list, but the udev rules, modules configuration, sysusers configuration, Vulkan layer, polkit rule, and profile script are not. This can leave the Moonshine binary and service in place after an update while part of its system integration has disappeared.

## Why this is needed

SteamOS's [atomic-update keep-list](https://github.com/evlaV/steamos-customizations/blob/jupiter-20260721.1/atomic-update/rauc/atomic-update-keep.conf.in#L1-L8) is explicit:

> When an atomic update is applied, all changes made in /etc will be lost.  
> The only exceptions are the files and directories listed below.

It also documents the supported extension point and why the list should remain narrow:

> If you want to preserve additional files, you can create drop-in '*.conf' files in "@atomic_update_conf_d@/".  
> Indiscriminately preserving /etc files increases the risk of encountering unexpected behavior, please proceed only if you know what you are doing.

The migration implementation loads [user-defined drop-ins](https://github.com/evlaV/steamos-customizations/blob/jupiter-20260721.1/misc/libexec/holo-sync-var.in#L233-L240) alongside the default list. Its [final rsync rule](https://github.com/evlaV/steamos-customizations/blob/jupiter-20260721.1/misc/libexec/holo-sync-var.in#L274-L288) is a catch-all exclusion:

> `--exclude="*"` is the final catch-all, to exclude all the files that were not explicitly listed in the config file.

Alberto Garcia's [SteamOS explanation](https://blogs.igalia.com/berto/2025/02/05/keeping-your-system-wide-configuration-files-intact-after-updating-steamos/) describes this as the intended third-party integration:

> users (or developers of third-party tools) can add a configuration file to `/etc/atomic-update.conf.d`, listing the additional files that need to be kept.

The [SteamOS issue discussion](https://github.com/ValveSoftware/SteamOS/issues/2151#issuecomment-3437575217) also explains how to validate persistence:

> Testing if changes survive an OS update can be done pretty simply by making your changes then switching branches of the OS and performing an update.

This PR adds a narrow atomic-update drop-in containing only the files managed by Moonshine. The portable release includes it, the installer registers it when `/etc/atomic-update.conf.d` exists, and uninstall removes it again.

## Testing

- `bash -n dist/moonshine-install.sh`
- `git diff --check`
- `pixi exec actionlint .github/workflows/release.yaml`
- `pixi exec shellcheck dist/moonshine-install.sh` reports the existing SC2015 and SC2269 informational findings, which reproduce on `main`
- `pixi exec shellcheck --exclude=SC2015,SC2269 dist/moonshine-install.sh`
- Audited every `/etc` path written by the installer against the keep-list
- Staged the expected portable tarball path and confirmed it matches the installer source path

