### PR TITLE
fix(hdr): make the injected AV1 HDR metadata OBUs spec-valid

### DIFF
--- a/moonshine-core/src/session/stream/video/pipeline/hdr_sei.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/hdr_sei.rs
@@ -138,7 +138,7 @@ fn build_av1_cll_obu(m: &HdrMetadata) -> Vec<u8> {
 	payload.extend(m.max_cll.to_be_bytes());
 	payload.extend(m.max_fall.to_be_bytes());
 
-	build_av1_obu(5, &payload) // obu_type = OBU_METADATA = 5
+	build_av1_metadata_obu(&payload)
 }
 
 /// Build AV1 OBU metadata for HDR MDCV (metadata_type = 2).
@@ -158,22 +158,24 @@ fn build_av1_mdcv_obu(m: &HdrMetadata) -> Vec<u8> {
 	payload.extend(m.max_luminance.to_be_bytes());
 	payload.extend(m.min_luminance.to_be_bytes());
 
-	build_av1_obu(5, &payload) // obu_type = OBU_METADATA = 5
+	build_av1_metadata_obu(&payload)
 }
 
-/// Build a complete AV1 OBU with header and size.
-fn build_av1_obu(obu_type: u8, payload: &[u8]) -> Vec<u8> {
-	// OBU header byte: obu_forbidden_bit (1) = 0, obu_type (4), obu_extension_flag (1) = 0,
-	// obu_has_size_field (1) = 1, obu_reserved_1bit (1) = 0.
-	let header_byte = (obu_type << 3) | 0x02; // has_size = 1
+/// Build a complete AV1 metadata OBU (type 5) with header, size and trailing
+/// bits.
+fn build_av1_metadata_obu(payload: &[u8]) -> Vec<u8> {
+	// OBU header byte: obu_forbidden_bit (1) = 0, obu_type (4) = 5 (OBU_METADATA),
+	// obu_extension_flag (1) = 0, obu_has_size_field (1) = 1, obu_reserved_1bit (1) = 0.
+	const OBU_METADATA_HEADER: u8 = (5 << 3) | 0x02;
 
+	// AV1 spec 5.3.1: a metadata OBU ends with `trailing_bits`, counted in
+	// `obu_size`. The payloads here are byte-aligned, so that is a single stop
+	// byte, the same `0x80` the H.26x SEI path appends.
 	let mut obu = Vec::new();
-	obu.push(header_byte);
-
-	// Size field (leb128-encoded payload length).
-	leb128_encode(&mut obu, payload.len() as u64);
-
+	obu.push(OBU_METADATA_HEADER);
+	leb128_encode(&mut obu, (payload.len() + 1) as u64);
 	obu.extend_from_slice(payload);
+	obu.push(0x80);
 	obu
 }
 
@@ -531,12 +533,48 @@ mod tests {
 	#[test]
 	fn test_av1_obu_structure() {
 		let m = test_metadata();
-		let cll_obu = build_av1_cll_obu(&m);
+		const METADATA_OBU_HEADER: u8 = (5 << 3) | 0x02;
 
-		// OBU header: type=5 (metadata), has_size=1.
-		assert_eq!(cll_obu[0], (5 << 3) | 0x02);
+		// header, size=6, metadata_type=1, max_cll=1000, max_fall=400, stop byte.
+		assert_eq!(
+			build_av1_cll_obu(&m),
+			vec![METADATA_OBU_HEADER, 6, 1, 0x03, 0xE8, 0x01, 0x90, 0x80]
+		);
 
 		let mdcv_obu = build_av1_mdcv_obu(&m);
-		assert_eq!(mdcv_obu[0], (5 << 3) | 0x02);
+		assert_eq!(mdcv_obu[0], METADATA_OBU_HEADER);
+		assert_eq!(mdcv_obu[2], 2, "metadata_type = METADATA_TYPE_HDR_MDCV");
+		assert_eq!(*mdcv_obu.last().unwrap(), 0x80, "trailing bits");
+	}
+
+	/// `obu_size` counts the trailing bits, so a decoder that trusts it reads
+	/// the whole OBU and no more.
+	#[test]
+	fn test_av1_obu_size_matches_payload() {
+		let m = test_metadata();
+		for obu in [build_av1_cll_obu(&m), build_av1_mdcv_obu(&m)] {
+			let (size, size_bytes) = leb128_decode(&obu[1..]);
+			assert_eq!(size as usize, obu.len() - 1 - size_bytes);
+		}
+	}
+
+	/// AV1 metadata must precede the frame it describes.
+	#[test]
+	fn test_inject_av1_inserts_before_frame_obu() {
+		let m = test_metadata();
+		// Temporal delimiter (type 2, size 0) then a frame OBU (type 6).
+		let td = [0x12u8, 0x00];
+		let frame = [0x32u8, 0x02, 0xAA, 0xBB];
+		let data: Vec<u8> = td.iter().chain(frame.iter()).copied().collect();
+
+		let out = inject_av1_metadata(&data, &m);
+		let mdcv = build_av1_mdcv_obu(&m);
+		let cll = build_av1_cll_obu(&m);
+
+		let mut expected = td.to_vec();
+		expected.extend_from_slice(&mdcv);
+		expected.extend_from_slice(&cll);
+		expected.extend_from_slice(&frame);
+		assert_eq!(out, expected);
 	}
 }

--- a/moonshine-core/src/session/stream/video/pipeline/hdr_sei.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/hdr_sei.rs
@@ -141,22 +141,44 @@ fn build_av1_cll_obu(m: &HdrMetadata) -> Vec<u8> {
 	build_av1_metadata_obu(&payload)
 }
 
-/// Build AV1 OBU metadata for HDR MDCV (metadata_type = 2).
+/// Convert a chromaticity coordinate from the 0.00002 steps of H.26x MDCV SEI
+/// (the `HdrMetadata` scale) to AV1's 0.16 fixed-point scale.
+fn av1_chromaticity(value: u16) -> u16 {
+	// value / 50000 * 65536, rounded; 50000 (chromaticity 1.0) does not fit
+	// 16 bits and saturates.
+	((u64::from(value) * 65536 + 25000) / 50000).min(u64::from(u16::MAX)) as u16
+}
+
+/// Convert a luminance from 0.0001 cd/m² units (the `HdrMetadata` scale) to
+/// AV1's 24.8 fixed-point `luminance_max`. The scale shrinks by 10000/256, so
+/// unlike [`av1_luminance_min`] no input can overflow the field.
+fn av1_luminance_max(value: u32) -> u32 {
+	((u64::from(value) * 256 + 5000) / 10000) as u32
+}
+
+/// Convert a luminance from 0.0001 cd/m² units (the `HdrMetadata` scale) to
+/// AV1's 18.14 fixed-point `luminance_min`.
+fn av1_luminance_min(value: u32) -> u32 {
+	((u64::from(value) * 16384 + 5000) / 10000).min(u64::from(u32::MAX)) as u32
+}
+
+/// Build AV1 OBU metadata for HDR MDCV (metadata_type = 2), converting the
+/// values into AV1's units (spec 6.7.4).
 fn build_av1_mdcv_obu(m: &HdrMetadata) -> Vec<u8> {
 	let mut payload = Vec::new();
 	// metadata_type = 2 (METADATA_TYPE_HDR_MDCV), leb128 encoded.
 	payload.push(2);
 	// Display primaries (RGB order, u16 BE each).
 	for &(x, y) in &m.display_primaries {
-		payload.extend(x.to_be_bytes());
-		payload.extend(y.to_be_bytes());
+		payload.extend(av1_chromaticity(x).to_be_bytes());
+		payload.extend(av1_chromaticity(y).to_be_bytes());
 	}
 	// White point.
-	payload.extend(m.white_point.0.to_be_bytes());
-	payload.extend(m.white_point.1.to_be_bytes());
+	payload.extend(av1_chromaticity(m.white_point.0).to_be_bytes());
+	payload.extend(av1_chromaticity(m.white_point.1).to_be_bytes());
 	// Luminance (u32 BE).
-	payload.extend(m.max_luminance.to_be_bytes());
-	payload.extend(m.min_luminance.to_be_bytes());
+	payload.extend(av1_luminance_max(m.max_luminance).to_be_bytes());
+	payload.extend(av1_luminance_min(m.min_luminance).to_be_bytes());
 
 	build_av1_metadata_obu(&payload)
 }
@@ -543,8 +565,26 @@ mod tests {
 
 		let mdcv_obu = build_av1_mdcv_obu(&m);
 		assert_eq!(mdcv_obu[0], METADATA_OBU_HEADER);
+		assert_eq!(mdcv_obu[1], 26, "1 type + 24 payload + 1 trailing byte");
 		assert_eq!(mdcv_obu[2], 2, "metadata_type = METADATA_TYPE_HDR_MDCV");
 		assert_eq!(*mdcv_obu.last().unwrap(), 0x80, "trailing bits");
+	}
+
+	/// Anchors are derived independently: D65 is x=0.3127, y=0.3290, and
+	/// 0.3127 * 65536 = 20493.1.
+	#[test]
+	fn test_av1_mdcv_units_are_av1_fixed_point() {
+		assert_eq!(av1_chromaticity(15635), 20493); // D65 x
+		assert_eq!(av1_chromaticity(16450), 21561); // D65 y
+		assert_eq!(av1_chromaticity(0), 0);
+		// Chromaticity 1.0 needs 65536 and saturates at the field maximum.
+		assert_eq!(av1_chromaticity(50000), u16::MAX);
+
+		// 1000 nits: 1000 * 256 in 24.8.
+		assert_eq!(av1_luminance_max(10_000_000), 256_000);
+		// 0.05 nits: 0.05 * 16384 = 819.2 in 18.14.
+		assert_eq!(av1_luminance_min(500), 819);
+		assert_eq!(av1_luminance_min(u32::MAX), u32::MAX, "saturates");
 	}
 
 	/// `obu_size` counts the trailing bits, so a decoder that trusts it reads
@@ -575,6 +615,30 @@ mod tests {
 		expected.extend_from_slice(&mdcv);
 		expected.extend_from_slice(&cll);
 		expected.extend_from_slice(&frame);
+		assert_eq!(out, expected);
+	}
+
+	/// An encoder may emit padding OBUs (type 15) after the sequence header;
+	/// metadata still goes in front of the frame, not the padding.
+	#[test]
+	fn test_inject_av1_skips_leading_non_frame_obus() {
+		let m = test_metadata();
+		let mut data = Vec::new();
+		data.extend_from_slice(&[0x12, 0x00]); // temporal delimiter
+		data.extend_from_slice(&[0x0A, 0x02, 0xC0, 0xDE]); // sequence header, size 2
+		data.extend_from_slice(&[0x7A, 0x03, 0xAA, 0xAA, 0xAA]); // padding, size 3
+		let frame_pos = data.len();
+		data.extend_from_slice(&[0x32, 0x02, 0xAA, 0xBB]); // frame, size 2
+
+		assert_eq!(find_first_frame_obu(&data), frame_pos);
+
+		// The metadata lands after the padding and before the frame, so the
+		// leading OBUs reach the decoder unchanged.
+		let out = inject_av1_metadata(&data, &m);
+		let mut expected = data[..frame_pos].to_vec();
+		expected.extend_from_slice(&build_av1_mdcv_obu(&m));
+		expected.extend_from_slice(&build_av1_cll_obu(&m));
+		expected.extend_from_slice(&data[frame_pos..]);
 		assert_eq!(out, expected);
 	}
 }


### PR DESCRIPTION
Found by Fable when investigating a green screen in the AV1 HDR path during AC4 Resynced gameplay. It turned out not to be THE reason for that green screen (that one is the SDR->HDR switch mid-stream, https://github.com/hgaiser/moonshine/issues/155), but it's an actual bug on its own. Fable is much smarter than me, so I had to go study a little how things operate under the hood in AV1 - attaching references for future folks that might land on this PR:

* [AV1 spec, 5.3.1 General OBU syntax](https://aomediacodec.github.io/av1-spec/#general-obu-syntax) - every OBU except OBU_TILE_GROUP, OBU_TILE_LIST and OBU_FRAME ends with `trailing_bits()`, and `obu_size` counts them
* [AV1 spec, 6.7.4 Metadata high dynamic range mastering display color volume semantics](https://aomediacodec.github.io/av1-spec/#metadata-high-dynamic-range-mastering-display-color-volume-semantics) - chromaticities are `x/65536`, `luminance_max` is in 1/256 cd/m² steps, `luminance_min` in 1/16384
* [H.265 spec](https://www.itu.int/rec/T-REC-H.265), D.3.28 mastering display colour volume SEI - the units `HdrMetadata` carries (0.00002 chromaticity steps, 0.0001 cd/m² luminance), which the H.26x SEI path writes as-is
* [dav1d src/obu.c, check_trailing_bits](https://code.videolan.org/videolan/dav1d/-/blob/master/src/obu.c) - the real-world enforcement: no trailing bits, no frame

The AV1 links point at the HTML working copy since it's the only deep-linkable form; the approved spec is the [PDF](https://aomediacodec.github.io/av1-spec/av1-spec.pdf), same section numbers.

With that out of the gate, this PR makes the HDR metadata OBUs we inject before AV1 key frames spec-valid:

1. Terminates the CLL and MDCV OBUs with trailing bits, counted in `obu_size`. Without them dav1d rejects the OBU and loses the key frame it precedes with it - in our tests a pre-fix stream decodes to exactly zero frames.
2. Converts MDCV values from the SEI units into AV1's units when building the OBU. Decoders accepted them before, but read nonsense: our 0.680 red primary decoded as 0.540, 1000 nits max luminance as 39062. Wrong tone mapping, not a decode failure.

Testing:

* End to end on real NVENC AV1 output (4K, 10-bit, full range, mid-stream SDR<->HDR switches): pre-fix streams hard-fail in dav1d ("Invalid argument", zero frames) and ffmpeg's parser; post-fix, dav1d 1.5.4, ffmpeg and nvdec decode every frame, and ffprobe reads the exact metadata values back.
* Also decodes clean on a Steam Machine's VAAPI stack.
