### PR TITLE
fix(video): split GSO sends to fit the kernel's UDP limits

### DIFF
--- a/moonshine-core/src/session/stream/video/gso_socket.rs
+++ b/moonshine-core/src/session/stream/video/gso_socket.rs
@@ -1,0 +1,171 @@
+use quinn_udp::{Transmit, UdpSockRef, UdpSocketState};
+use tokio::net::UdpSocket;
+
+use super::shard_batch::ShardBatch;
+
+/// Maximum payload of one UDP datagram (65535 minus IPv4/UDP headers).
+/// A GSO batch is still one datagram: the kernel rejects anything larger
+/// with EMSGSIZE before segmenting. IPv6 allows 20 more bytes; the IPv4
+/// value is safe for both.
+const MAX_UDP_PAYLOAD: usize = 65507;
+
+/// Number of shards per GSO send: the kernel's segment-count cap or the
+/// datagram-size cap, whichever binds first. Never zero, even for a shard
+/// larger than a datagram (such a chunk fails at send time and falls back
+/// to per-shard sends, which fail visibly instead of silently).
+fn gso_segments_per_send(max_gso_segments: usize, shard_size: usize) -> usize {
+	max_gso_segments
+		.min(MAX_UDP_PAYLOAD.checked_div(shard_size).unwrap_or(0))
+		.max(1)
+}
+
+/// UDP socket for the video stream, with Generic Segmentation Offload.
+///
+/// Wraps a `tokio::net::UdpSocket` and quinn-udp's `UdpSocketState` so shard
+/// batches can be sent as GSO super-packets sized to the kernel's segment-count
+/// and datagram-size caps. Batches exceeding a cap are split into chunks; chunks
+/// the kernel rejects fall back to per-shard sends. Without GSO support, the
+/// socket sends everything per-shard.
+pub(crate) struct UdpGsoSocket {
+	socket: UdpSocket,
+	udp_state: UdpSocketState,
+}
+
+impl UdpGsoSocket {
+	/// Bind a socket to `address:port` and initialize its GSO state.
+	pub async fn new(address: &str, port: u16) -> Result<Self, ()> {
+		let socket = UdpSocket::bind((address, port))
+			.await
+			.map_err(|e| tracing::error!("Failed to bind to UDP socket: {e}"))?;
+		let udp_state = UdpSocketState::new(UdpSockRef::from(&socket))
+			.map_err(|e| tracing::error!("Failed to initialize UDP socket state: {e}"))?;
+		if udp_state.max_gso_segments() > 1 {
+			tracing::info!("GSO enabled, max segments: {}", udp_state.max_gso_segments());
+		} else {
+			tracing::info!("GSO not available, using per-shard sends");
+		}
+		Ok(Self { socket, udp_state })
+	}
+
+	/// Local address the socket is bound to.
+	pub fn local_addr(&self) -> std::io::Result<std::net::SocketAddr> {
+		self.socket.local_addr()
+	}
+
+	/// Apply QoS marking (IPv4 ToS) to sent packets.
+	pub fn set_tos_v4(&self, tos: u32) -> std::io::Result<()> {
+		self.socket.set_tos_v4(tos)
+	}
+
+	/// Receive a datagram (e.g. the client's `PING`).
+	pub async fn recv_from(&self, buf: &mut [u8]) -> std::io::Result<(usize, std::net::SocketAddr)> {
+		self.socket.recv_from(buf).await
+	}
+
+	/// Send a shard batch to `addr`.
+	///
+	/// Returns the number of chunks that fell back to per-shard sends because
+	/// the kernel rejected the GSO send (0 on success).
+	///
+	/// GSO availability is re-checked on every call: quinn-udp disables it at
+	/// runtime if the kernel or NIC rejects a segmented send.
+	pub async fn send_batch(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> u32 {
+		if self.udp_state.max_gso_segments() > 1 {
+			self.send_batch_gso(batch, addr).await
+		} else {
+			self.send_shards(batch.as_bytes(), batch.shard_size(), addr).await;
+			0
+		}
+	}
+
+	/// Send a batch as GSO chunks sized to the kernel's segment and datagram
+	/// caps; a frame's batch routinely exceeds both. Uses `try_send` because
+	/// `send` masks every error except `WouldBlock` as success, silently
+	/// discarding the batch.
+	async fn send_batch_gso(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> u32 {
+		let shard_size = batch.shard_size();
+		if shard_size == 0 {
+			return 0;
+		}
+		let segments_per_send = gso_segments_per_send(self.udp_state.max_gso_segments(), shard_size);
+
+		let mut failed_chunks = 0u32;
+		for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
+			let transmit = Transmit {
+				destination: addr,
+				ecn: None,
+				contents: chunk,
+				segment_size: Some(shard_size),
+				src_ip: None,
+			};
+			let result = loop {
+				match self.udp_state.try_send(UdpSockRef::from(&self.socket), &transmit) {
+					// A frame burst can outrun the socket buffer; wait for it to
+					// drain and resend the same chunk instead of degrading.
+					Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+						self.socket.writable().await.ok();
+					},
+					other => break other,
+				}
+			};
+			if let Err(e) = result {
+				failed_chunks += 1;
+				tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
+				self.send_shards(chunk, shard_size, addr).await;
+			}
+		}
+		failed_chunks
+	}
+
+	/// Send a contiguous buffer of equal-sized shards as individual UDP packets.
+	async fn send_shards(&self, bytes: &[u8], shard_size: usize, addr: std::net::SocketAddr) {
+		if shard_size == 0 {
+			return;
+		}
+		for shard in bytes.chunks(shard_size) {
+			if let Err(e) = self.socket.send_to(shard, addr).await {
+				tracing::warn!("Failed to send packet to client: {e}");
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn gso_segment_count_cap_binds() {
+		// Payload cap (65507 / 100 = 655) is looser than the segment cap.
+		assert_eq!(gso_segments_per_send(8, 100), 8);
+	}
+
+	#[test]
+	fn gso_payload_cap_binds() {
+		// 65507 / 2000 = 32, tighter than the kernel's 64-segment cap.
+		assert_eq!(gso_segments_per_send(64, 2000), 32);
+	}
+
+	#[test]
+	fn gso_boundary_shard_sizes() {
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD), 1);
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD - 1), 1);
+		// A shard that cannot fit a datagram at all still yields 1, not 0.
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD + 1), 1);
+		assert_eq!(gso_segments_per_send(64, 0), 1);
+	}
+
+	#[test]
+	fn gso_chunks_respect_kernel_limits() {
+		// Shard counts chosen to force a partial final chunk.
+		for (shard_count, shard_size) in [(250usize, 1404usize), (47, 1404), (100, 733)] {
+			let segments = gso_segments_per_send(64, shard_size);
+			let data = vec![0u8; shard_count * shard_size];
+			for chunk in data.chunks(segments * shard_size) {
+				assert_eq!(chunk.len() % shard_size, 0, "chunk must hold whole shards");
+				assert!(chunk.len() <= MAX_UDP_PAYLOAD, "chunk must fit one datagram");
+				assert!(chunk.len() / shard_size <= 64, "chunk must respect segment cap");
+			}
+		}
+	}
+}

--- a/moonshine-core/src/session/stream/video/mod.rs
+++ b/moonshine-core/src/session/stream/video/mod.rs
@@ -1,20 +1,18 @@
 use std::sync::Arc;
 
 use async_shutdown::ShutdownManager;
-use quinn_udp::{Transmit, UdpSockRef, UdpSocketState};
 use serde::{Deserialize, Serialize};
-use tokio::{
-	net::UdpSocket,
-	sync::{Notify, broadcast, mpsc, watch},
-};
+use tokio::sync::{Notify, broadcast, mpsc, watch};
 
 use crate::session::SessionKeysReceiver;
 use crate::session::compositor::frame::{ExportedFrame, HdrModeState};
 use crate::session::manager::SessionShutdownReason;
 
+mod gso_socket;
 mod packetizer;
 mod pipeline;
 mod shard_batch;
+use gso_socket::UdpGsoSocket;
 use pipeline::VideoPipeline;
 use shard_batch::ShardBatch;
 
@@ -234,7 +232,7 @@ impl VideoStreamHandle {
 }
 
 pub(crate) struct VideoStream {
-	socket: UdpSocket,
+	socket: UdpGsoSocket,
 	frame_rx: std::sync::mpsc::Receiver<ExportedFrame>,
 	hdr_metadata_tx: watch::Sender<HdrModeState>,
 	stats_tx: tokio::sync::broadcast::Sender<FrameStats>,
@@ -251,9 +249,7 @@ impl VideoStream {
 	) -> Result<Self, ()> {
 		tracing::debug!("Initializing video stream.");
 
-		let socket = UdpSocket::bind((address.as_str(), config.port))
-			.await
-			.map_err(|e| tracing::error!("Failed to bind to UDP socket: {e}"))?;
+		let socket = UdpGsoSocket::new(&address, config.port).await?;
 
 		tracing::debug!(
 			"Listening for video messages on {}",
@@ -290,16 +286,6 @@ impl VideoStream {
 			let _ = socket.set_tos_v4(160);
 		}
 
-		// Initialize quinn-udp state for GSO support.
-		let udp_state = UdpSocketState::new(UdpSockRef::from(&socket))
-			.map_err(|e| tracing::error!("Failed to initialize UDP socket state: {e}"))?;
-		let gso_enabled = udp_state.max_gso_segments() > 1;
-		if gso_enabled {
-			tracing::info!("GSO enabled, max segments: {}", udp_state.max_gso_segments());
-		} else {
-			tracing::info!("GSO not available, using per-shard sends");
-		}
-
 		// Gate for pipeline + packet handler.
 		let start_notify = Arc::new(Notify::new());
 
@@ -317,7 +303,7 @@ impl VideoStream {
 		let (packet_tx, packet_rx) = mpsc::channel::<ShardBatch>(128);
 
 		// Spawn packet handler — gated behind start_notify.
-		spawn_handle_video_packets(packet_rx, socket, udp_state, start_notify.clone(), stop.clone());
+		spawn_handle_video_packets(packet_rx, socket, start_notify.clone(), stop.clone());
 
 		// Spawn pipeline thread — gated behind start_notify.
 		VideoPipeline::new(
@@ -347,8 +333,7 @@ impl VideoStream {
 
 fn spawn_handle_video_packets(
 	mut packet_rx: mpsc::Receiver<ShardBatch>,
-	socket: UdpSocket,
-	udp_state: UdpSocketState,
+	socket: UdpGsoSocket,
 	start: Arc<Notify>,
 	stop_session_manager: ShutdownManager<SessionShutdownReason>,
 ) {
@@ -374,35 +359,24 @@ fn spawn_handle_video_packets(
 									continue;
 								}
 
-								// Try GSO first if available (check dynamically —
-								// quinn-udp may disable GSO after a send failure).
 								// Sends are wrapped in wrap_cancel so a socket that
 								// stops draining cannot block session shutdown.
-								let use_gso = udp_state.max_gso_segments() > 1;
-								if use_gso {
-									match stop_session_manager
-										.wrap_cancel(send_batch_gso(&socket, &udp_state, &batch, addr))
-										.await
-									{
-										Ok(failed_chunks) => {
-											if failed_chunks > 0
-												&& last_send_warn
-													.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))
-											{
-												tracing::warn!(
-													"GSO send failed for {failed_chunks} chunk(s), sent per-shard instead"
-												);
-												last_send_warn = Some(std::time::Instant::now());
-											}
-										},
-										Err(_) => break,
-									}
-								} else if stop_session_manager
-									.wrap_cancel(send_shards(&socket, &batch, addr))
+								match stop_session_manager
+									.wrap_cancel(socket.send_batch(&batch, addr))
 									.await
-									.is_err()
 								{
-									break;
+									Ok(failed_chunks) => {
+										if failed_chunks > 0
+											&& last_send_warn
+												.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))
+										{
+											tracing::warn!(
+												"GSO send failed for {failed_chunks} chunk(s), sent per-shard instead"
+											);
+											last_send_warn = Some(std::time::Instant::now());
+										}
+									},
+									Err(_) => break,
 								}
 							}
 						},
@@ -436,122 +410,4 @@ fn spawn_handle_video_packets(
 
 		tracing::debug!("Video packet stream stopped.");
 	});
-}
-
-/// Maximum payload of one UDP datagram (65535 minus IPv4/UDP headers).
-/// A GSO batch is still one datagram: the kernel rejects anything larger
-/// with EMSGSIZE before segmenting. IPv6 allows 20 more bytes; the IPv4
-/// value is safe for both.
-const MAX_UDP_PAYLOAD: usize = 65507;
-
-/// Number of shards per GSO send: the kernel's segment-count cap or the
-/// datagram-size cap, whichever binds first. Never zero, even for a shard
-/// larger than a datagram (such a chunk fails at send time and falls back
-/// to per-shard sends, which fail visibly instead of silently).
-fn gso_segments_per_send(max_gso_segments: usize, shard_size: usize) -> usize {
-	max_gso_segments
-		.min(MAX_UDP_PAYLOAD.checked_div(shard_size).unwrap_or(0))
-		.max(1)
-}
-
-/// Send a batch as GSO chunks sized to the kernel's segment and datagram
-/// caps; a frame's batch routinely exceeds both. Uses `try_send` because
-/// `send` masks every error except `WouldBlock` as success, silently
-/// discarding the batch. Returns the number of chunks that fell back to
-/// per-shard sends, so the caller can rate-limit the warning.
-async fn send_batch_gso(
-	socket: &UdpSocket,
-	udp_state: &UdpSocketState,
-	batch: &ShardBatch,
-	addr: std::net::SocketAddr,
-) -> u32 {
-	let shard_size = batch.shard_size();
-	if shard_size == 0 {
-		return 0;
-	}
-	let segments_per_send = gso_segments_per_send(udp_state.max_gso_segments(), shard_size);
-
-	let mut failed_chunks = 0u32;
-	for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
-		let transmit = Transmit {
-			destination: addr,
-			ecn: None,
-			contents: chunk,
-			segment_size: Some(shard_size),
-			src_ip: None,
-		};
-		let result = loop {
-			match udp_state.try_send(UdpSockRef::from(socket), &transmit) {
-				// A frame burst can outrun the socket buffer; wait for it to
-				// drain and resend the same chunk instead of degrading.
-				Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-					socket.writable().await.ok();
-				},
-				other => break other,
-			}
-		};
-		if let Err(e) = result {
-			failed_chunks += 1;
-			tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
-			send_shard_bytes(socket, chunk, shard_size, addr).await;
-		}
-	}
-	failed_chunks
-}
-
-/// Send all shards in a batch as individual UDP packets.
-async fn send_shards(socket: &UdpSocket, batch: &ShardBatch, addr: std::net::SocketAddr) {
-	send_shard_bytes(socket, batch.as_bytes(), batch.shard_size(), addr).await;
-}
-
-/// Send a contiguous buffer of equal-sized shards as individual UDP packets.
-async fn send_shard_bytes(socket: &UdpSocket, bytes: &[u8], shard_size: usize, addr: std::net::SocketAddr) {
-	if shard_size == 0 {
-		return;
-	}
-	for shard in bytes.chunks(shard_size) {
-		if let Err(e) = socket.send_to(shard, addr).await {
-			tracing::warn!("Failed to send packet to client: {e}");
-		}
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn gso_segment_count_cap_binds() {
-		// Payload cap (65507 / 100 = 655) is looser than the segment cap.
-		assert_eq!(gso_segments_per_send(8, 100), 8);
-	}
-
-	#[test]
-	fn gso_payload_cap_binds() {
-		// 65507 / 2000 = 32, tighter than the kernel's 64-segment cap.
-		assert_eq!(gso_segments_per_send(64, 2000), 32);
-	}
-
-	#[test]
-	fn gso_boundary_shard_sizes() {
-		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD), 1);
-		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD - 1), 1);
-		// A shard that cannot fit a datagram at all still yields 1, not 0.
-		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD + 1), 1);
-		assert_eq!(gso_segments_per_send(64, 0), 1);
-	}
-
-	#[test]
-	fn gso_chunks_respect_kernel_limits() {
-		// Shard counts chosen to force a partial final chunk.
-		for (shard_count, shard_size) in [(250usize, 1404usize), (47, 1404), (100, 733)] {
-			let segments = gso_segments_per_send(64, shard_size);
-			let data = vec![0u8; shard_count * shard_size];
-			for chunk in data.chunks(segments * shard_size) {
-				assert_eq!(chunk.len() % shard_size, 0, "chunk must hold whole shards");
-				assert!(chunk.len() <= MAX_UDP_PAYLOAD, "chunk must fit one datagram");
-				assert!(chunk.len() / shard_size <= 64, "chunk must respect segment cap");
-			}
-		}
-	}
 }

--- a/moonshine-core/src/session/stream/video/mod.rs
+++ b/moonshine-core/src/session/stream/video/mod.rs
@@ -357,6 +357,8 @@ fn spawn_handle_video_packets(
 
 		let mut buf = [0; 1024];
 		let mut client_address = None;
+		// Rate-limits the GSO-fallback warning.
+		let mut last_send_warn: Option<std::time::Instant> = None;
 
 		// Trigger session shutdown if we exit unexpectedly.
 		let _stop_token = stop_session_manager.trigger_shutdown_token(SessionShutdownReason::VideoPacketHandlerStopped);
@@ -374,30 +376,33 @@ fn spawn_handle_video_packets(
 
 								// Try GSO first if available (check dynamically —
 								// quinn-udp may disable GSO after a send failure).
+								// Sends are wrapped in wrap_cancel so a socket that
+								// stops draining cannot block session shutdown.
 								let use_gso = udp_state.max_gso_segments() > 1;
 								if use_gso {
-									let transmit = Transmit {
-										destination: addr,
-										ecn: None,
-										contents: batch.as_bytes(),
-										segment_size: Some(batch.shard_size()),
-										src_ip: None,
-									};
-									match udp_state.send(UdpSockRef::from(&socket), &transmit) {
-										Ok(()) => {}
-										Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-											socket.writable().await.ok();
-											if udp_state.send(UdpSockRef::from(&socket), &transmit).is_err() {
-												send_shards(&socket, &batch, addr).await;
+									match stop_session_manager
+										.wrap_cancel(send_batch_gso(&socket, &udp_state, &batch, addr))
+										.await
+									{
+										Ok(failed_chunks) => {
+											if failed_chunks > 0
+												&& last_send_warn
+													.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))
+											{
+												tracing::warn!(
+													"GSO send failed for {failed_chunks} chunk(s), sent per-shard instead"
+												);
+												last_send_warn = Some(std::time::Instant::now());
 											}
-										}
-										Err(e) => {
-											tracing::debug!("GSO send failed ({e}), falling back to per-shard");
-											send_shards(&socket, &batch, addr).await;
-										}
+										},
+										Err(_) => break,
 									}
-								} else {
-									send_shards(&socket, &batch, addr).await;
+								} else if stop_session_manager
+									.wrap_cancel(send_shards(&socket, &batch, addr))
+									.await
+									.is_err()
+								{
+									break;
 								}
 							}
 						},
@@ -433,11 +438,120 @@ fn spawn_handle_video_packets(
 	});
 }
 
+/// Maximum payload of one UDP datagram (65535 minus IPv4/UDP headers).
+/// A GSO batch is still one datagram: the kernel rejects anything larger
+/// with EMSGSIZE before segmenting. IPv6 allows 20 more bytes; the IPv4
+/// value is safe for both.
+const MAX_UDP_PAYLOAD: usize = 65507;
+
+/// Number of shards per GSO send: the kernel's segment-count cap or the
+/// datagram-size cap, whichever binds first. Never zero, even for a shard
+/// larger than a datagram (such a chunk fails at send time and falls back
+/// to per-shard sends, which fail visibly instead of silently).
+fn gso_segments_per_send(max_gso_segments: usize, shard_size: usize) -> usize {
+	max_gso_segments
+		.min(MAX_UDP_PAYLOAD.checked_div(shard_size).unwrap_or(0))
+		.max(1)
+}
+
+/// Send a batch as GSO chunks sized to the kernel's segment and datagram
+/// caps; a frame's batch routinely exceeds both. Uses `try_send` because
+/// `send` masks every error except `WouldBlock` as success, silently
+/// discarding the batch. Returns the number of chunks that fell back to
+/// per-shard sends, so the caller can rate-limit the warning.
+async fn send_batch_gso(
+	socket: &UdpSocket,
+	udp_state: &UdpSocketState,
+	batch: &ShardBatch,
+	addr: std::net::SocketAddr,
+) -> u32 {
+	let shard_size = batch.shard_size();
+	if shard_size == 0 {
+		return 0;
+	}
+	let segments_per_send = gso_segments_per_send(udp_state.max_gso_segments(), shard_size);
+
+	let mut failed_chunks = 0u32;
+	for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
+		let transmit = Transmit {
+			destination: addr,
+			ecn: None,
+			contents: chunk,
+			segment_size: Some(shard_size),
+			src_ip: None,
+		};
+		let result = loop {
+			match udp_state.try_send(UdpSockRef::from(socket), &transmit) {
+				// A frame burst can outrun the socket buffer; wait for it to
+				// drain and resend the same chunk instead of degrading.
+				Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+					socket.writable().await.ok();
+				},
+				other => break other,
+			}
+		};
+		if let Err(e) = result {
+			failed_chunks += 1;
+			tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
+			send_shard_bytes(socket, chunk, shard_size, addr).await;
+		}
+	}
+	failed_chunks
+}
+
 /// Send all shards in a batch as individual UDP packets.
 async fn send_shards(socket: &UdpSocket, batch: &ShardBatch, addr: std::net::SocketAddr) {
-	for shard in batch.shards() {
+	send_shard_bytes(socket, batch.as_bytes(), batch.shard_size(), addr).await;
+}
+
+/// Send a contiguous buffer of equal-sized shards as individual UDP packets.
+async fn send_shard_bytes(socket: &UdpSocket, bytes: &[u8], shard_size: usize, addr: std::net::SocketAddr) {
+	if shard_size == 0 {
+		return;
+	}
+	for shard in bytes.chunks(shard_size) {
 		if let Err(e) = socket.send_to(shard, addr).await {
 			tracing::warn!("Failed to send packet to client: {e}");
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn gso_segment_count_cap_binds() {
+		// Payload cap (65507 / 100 = 655) is looser than the segment cap.
+		assert_eq!(gso_segments_per_send(8, 100), 8);
+	}
+
+	#[test]
+	fn gso_payload_cap_binds() {
+		// 65507 / 2000 = 32, tighter than the kernel's 64-segment cap.
+		assert_eq!(gso_segments_per_send(64, 2000), 32);
+	}
+
+	#[test]
+	fn gso_boundary_shard_sizes() {
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD), 1);
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD - 1), 1);
+		// A shard that cannot fit a datagram at all still yields 1, not 0.
+		assert_eq!(gso_segments_per_send(64, MAX_UDP_PAYLOAD + 1), 1);
+		assert_eq!(gso_segments_per_send(64, 0), 1);
+	}
+
+	#[test]
+	fn gso_chunks_respect_kernel_limits() {
+		// Shard counts chosen to force a partial final chunk.
+		for (shard_count, shard_size) in [(250usize, 1404usize), (47, 1404), (100, 733)] {
+			let segments = gso_segments_per_send(64, shard_size);
+			let data = vec![0u8; shard_count * shard_size];
+			for chunk in data.chunks(segments * shard_size) {
+				assert_eq!(chunk.len() % shard_size, 0, "chunk must hold whole shards");
+				assert!(chunk.len() <= MAX_UDP_PAYLOAD, "chunk must fit one datagram");
+				assert!(chunk.len() / shard_size <= 64, "chunk must respect segment cap");
+			}
 		}
 	}
 }

--- a/moonshine-core/src/session/stream/video/shard_batch.rs
+++ b/moonshine-core/src/session/stream/video/shard_batch.rs
@@ -19,16 +19,6 @@ impl ShardBatch {
 		}
 	}
 
-	/// Iterate over all shards as byte slices for sending.
-	pub fn shards(&self) -> impl Iterator<Item = &[u8]> {
-		let size = self.shard_size;
-		if size == 0 {
-			[].chunks_exact(1) // yields an empty iterator
-		} else {
-			self.data.chunks_exact(size)
-		}
-	}
-
 	/// Raw contiguous buffer for GSO sends.
 	pub fn as_bytes(&self) -> &[u8] {
 		&self.data


### PR DESCRIPTION
Closes #156.

The GSO path handed each frame's entire shard batch to a single send - 150-350KB at 4K bitrates. The kernel rejects `UDP_SEGMENT` sends over 65507 bytes with EMSGSIZE before anything reaches the wire, and quinn-udp's `send()` masks every error except `WouldBlock` as `Ok`, so oversized frames vanished silently and the per-shard fallback was dead code. At 150Mbps that's practically every frame; 28Mbps frames (~29KB) fit, which is why low bitrates were fine. Easy to check on loopback: 46 segments x 1404B deliver as 46 packets, 47 segments fail with EMSGSIZE.

The fix:

1. Split each batch into chunks of `min(max_gso_segments, 65507 / shard_size)` segments - a 250-shard frame goes out in 6 syscalls instead of 250, keeping the #138 win/s.
2. Use `try_send` so kernel errors actually reach the per-shard fallback; the warning is rate-limited to once per second.
3. Drain `WouldBlock` by awaiting writability and resending the same chunk - a frame burst can outrun the socket buffer.
4. Wrap sends in `wrap_cancel` so a stalled socket can't block session shutdown.
5. Unit tests for the cap arithmetic and chunk invariants. `ShardBatch::shards()` lost its last caller and is removed.

Testing: `cargo test -p moonshine-core` for the new tests; end to end at 4K/120Hz/150Mbps AV1 and HEVC - pre-fix freezes within seconds, post-fix streams flawlessly with GSO active and zero fallback warnings. 1080p/28Mbps unchanged.

---
Host: NVidia 5060 Ti (driver 610.43.03), Arch, VM on Proxmox with GPU passthrough
Client: SteamMachine (moonlight-qt from flathub), wired gigabit
