### PR TITLE
Fix XDG shell fullscreen requests by acknowledging them in configure

### DIFF
--- a/moonshine-core/src/session/compositor/handlers.rs
+++ b/moonshine-core/src/session/compositor/handlers.rs
@@ -1383,6 +1383,7 @@ impl XdgShellHandler for MoonshineCompositor {
 		// size.
 		surface.with_pending_state(|state| {
 			state.size = Some((self.width as i32, self.height as i32).into());
+			state.states.set(XdgToplevelState::Maximized);
 		});
 		surface.send_configure();
 
@@ -1443,50 +1444,37 @@ impl XdgShellHandler for MoonshineCompositor {
 	}
 
 	fn fullscreen_request(&mut self, surface: ToplevelSurface, _output: Option<WlOutput>) {
+		surface.with_pending_state(|state| {
+			state.states.set(XdgToplevelState::Fullscreen);
+		});
 		surface.send_configure();
+
 		// Update fullscreen state in metadata.
 		let target = surface.wl_surface();
+		let geometry = self.output_rect();
 		if let Some(window) = self.find_window_by_surface(target)
 			&& let Some(meta) = self.window_metadata.get_mut(&window)
 		{
-			surface.with_committed_state(|state| {
-				let is_fullscreen = state
-					.as_ref()
-					.map(|s| s.states.contains(XdgToplevelState::Fullscreen))
-					.unwrap_or(false);
-				if is_fullscreen != meta.fullscreen {
-					meta.fullscreen = is_fullscreen;
-					if let Some(s) = state
-						&& let Some(size) = s.size
-					{
-						meta.geometry = Rectangle::new((0, 0).into(), (size.w, size.h).into());
-					}
-				}
-			});
+			meta.fullscreen = true;
+			meta.geometry = geometry;
 		}
 		self.reevaluate_focus();
 	}
 
 	fn unfullscreen_request(&mut self, surface: ToplevelSurface) {
+		surface.with_pending_state(|state| {
+			state.states.unset(XdgToplevelState::Fullscreen);
+		});
+		surface.send_configure();
+
 		// Update fullscreen state in metadata.
 		let target = surface.wl_surface();
+		let geometry = self.output_rect();
 		if let Some(window) = self.find_window_by_surface(target)
 			&& let Some(meta) = self.window_metadata.get_mut(&window)
 		{
-			surface.with_committed_state(|state| {
-				let is_fullscreen = state
-					.as_ref()
-					.map(|s| s.states.contains(XdgToplevelState::Fullscreen))
-					.unwrap_or(false);
-				if !is_fullscreen && meta.fullscreen {
-					meta.fullscreen = false;
-					if let Some(s) = state
-						&& let Some(size) = s.size
-					{
-						meta.geometry = Rectangle::new((0, 0).into(), (size.w, size.h).into());
-					}
-				}
-			});
+			meta.fullscreen = false;
+			meta.geometry = geometry;
 		}
 		self.reevaluate_focus();
 	}


### PR DESCRIPTION
:wave: I was having trouble with ShadPS4 always showing the titlebar no matter what I did or what method I used to achieve fullscreen, it was just always there. What I expected to happen was whenever I pressed F11 the titlebar would either toggle on or off depending on if it was in fullscreen or not.

Digging in I found fullscreen/unfullscreen requests weren't really working. [Docs](https://wayland.app/protocols/xdg-shell#xdg_toplevel:request:set_fullscreen)

While both methods were calling `send_configure()`, they weren't actually acknowledging the request by actually setting `XdgToplevelState::Fullscreen` in that configure. It was then using `with_committed_state` to read the current state, but since it didn't actually tell the client it was changed to or from fullscreen, it would never hide or unhide its titlebar.

This PR solves that by setting/unsetting `XdgToplevelState::Fullscreen` before `send_configure()`. You can see smithay's reference compositor Anvil does something similar:
https://github.com/Smithay/smithay/blob/5fb12b87407b3680135c45d94214c5f1b1d0fbea/anvil/src/shell/xdg.rs#L290-L310

Additionally:
- I dropped the fullscreen check in `with_committed_state` because to the best of my ability to tell it's not necessary. It's entirely up to the compositor to decide whether it's in fullscreen or not, so once we've set `XdgToplevelState::Fullscreen` we can freely set the internal metadata to match.
- I set `XdgToplevelState::Maximized` in `new_toplevel`. Without this I found exiting fullscreen was not guaranteed to return to a state where it's filling the output, but given it seems the goal is a gamescope-style compositor that keeps things maximised, having `Maximized` set solves that.

