### PR TITLE
fix(hdr): inject AV1 metadata for full-range clients

### DIFF
--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -780,12 +780,7 @@ impl VideoPipelineInner {
 						match encoder.encode(encoder.input_image()) {
 							Ok(future) => {
 								let submitted_at = std::time::Instant::now();
-								// Deliberately still a whole-struct comparison, unlike the
-								// control-stream check above. Correcting it newly enables
-								// AV1 metadata injection for full-range clients, and that
-								// produces streams Moonlight cannot decode. Left until the
-								// AV1 path is fixed.
-								let inject_hdr = encoder_color_desc == Some(ColorDescription::bt2020_pq());
+								let inject_hdr = encoder_color_desc.is_some_and(|desc| desc.is_hdr());
 								let frame_context = FrameContext {
 									created_at: now,
 									channel_wait: std::time::Duration::ZERO,

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -1049,12 +1049,7 @@ impl VideoPipelineInner {
 						// Hand this frame's context plus its packet future to the
 						// consumer thread, which awaits the future, injects HDR SEI if
 						// needed, packetizes and sends it, and records stats.
-						// Deliberately still a whole-struct comparison, unlike the
-						// control-stream check above. Correcting it newly enables
-						// AV1 metadata injection for full-range clients, and that
-						// produces streams Moonlight cannot decode. Left until the
-						// AV1 path is fixed.
-						let inject_hdr = encoder_color_desc == Some(ColorDescription::bt2020_pq());
+						let inject_hdr = encoder_color_desc.is_some_and(|desc| desc.is_hdr());
 						let frame_context = FrameContext {
 							created_at: frame.created_at,
 							channel_wait: t1_received.duration_since(frame.created_at),


### PR DESCRIPTION
The `inject_hdr` gate still compares against the exact limited-range BT.2020+PQ preset, so full-range HDR sessions never carry MDCV/CLL metadata OBUs and the client tone-maps blind. The gate (and its comment) predates #154 - with the trailing-bits + AV1-units fixes in, the injected stream is spec-valid, so this drops the gate to `is_hdr()`, the same check the control-stream HDR state already uses.

Verified live: 4K AV1 full-range HDR session (moonlight-qt/VAAPI client), SDR→HDR transition plays with metadata injected. Also offline: captured the wire bitstream and the injected OBUs pass dav1d and `ffmpeg -err_detect explode`. Note this needs hgaiser/pixelforge#31 on the host to get a decodable transition key frame in the first place - independent bugs, but this one is only observable with that one fixed.

This finally fixes all of my troubles with AC4 on AV1 path, so I can finally start playing it rather than tinkering with the setup lol. (all of this was only for 1ms decode latency improvement vs HEVC path, heh).

Closes #155.

---
Host: NVidia 5060 Ti (driver 610.43.03), Arch