### PR TITLE
fix(audio): tolerate timerfd wakeups with no expirations

### DIFF
--- a/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
+++ b/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
@@ -315,8 +315,13 @@ impl PulseServer {
 			for event in events.iter() {
 				match event.token() {
 					CLOCK => {
-						self.clock.read()?;
-						self.clock_tick()?;
+						// A wakeup can race its own drain and find no expirations
+						// left to read (EAGAIN); skip the tick, don't kill the session.
+						match self.clock.read() {
+							Ok(_) => self.clock_tick()?,
+							Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => (),
+							Err(e) => return Err(e.into()),
+						}
 					},
 					LISTENER => loop {
 						let (mut socket, _) = match self.listener.accept() {


### PR DESCRIPTION
Had a live session die mid-game with `Session stopped unexpectedly (reason: PulseServerStopped)` - the audio clock's timerfd read returned EAGAIN and the `?` propagated it as fatal, tearing down the whole session (and the running app with it). A wakeup can race its own drain and find no expirations left to read; hit it in the wild under host memory pressure where the event loop was stalling (12s of buffer-underrun warnings first, then the EAGAIN).

The fix skips the tick on WouldBlock instead, which is how the accept and client-read arms of the same event loop already treat it. Real errors still propagate.

```
WARN  ...pulse_server: Buffer underrun for stream 6   (x many, ~12s)
ERROR ...pulse_server: PulseServer error: IO error: Resource temporarily unavailable (os error 11)
WARN  ...manager: Session stopped unexpectedly (reason: PulseServerStopped), waiting for new session.
```

---
Host: NVidia 5060 Ti (driver 610.43.03), Arch