### PR TITLE
fix: discover Heroic libraries and read GOG install state from its manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Read GOG install state from Heroic's `gog_store/installed.json`, which Heroic strips out of the library cache, so the Heroic scanner no longer skips every installed GOG game. (#169, @scottjab)
+- Prefer Heroic's cached cover art over its shortcut icons, so GOG games no longer show a small square store logo as their box art. (#169, @scottjab)
 
 
 ## [v0.15.0] - 05-08-2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Read GOG install state from Heroic's `gog_store/installed.json`, which Heroic strips out of the library cache, so the Heroic scanner no longer skips every installed GOG game. (#169, @scottjab)
+
+
 ## [v0.15.0] - 05-08-2026
 
 ### Added

--- a/moonshine-core/src/app_scanner/heroic.rs
+++ b/moonshine-core/src/app_scanner/heroic.rs
@@ -65,7 +65,7 @@ fn find_libraries(config_dir: &Path) -> Vec<PathBuf> {
 			})
 			.collect(),
 		Err(e) => {
-			tracing::debug!("Failed to read Heroic store cache {:?}: {e}", store_cache);
+			tracing::warn!("Failed to read Heroic store cache {:?}: {e}", store_cache);
 			Vec::new()
 		},
 	};

--- a/moonshine-core/src/app_scanner/heroic.rs
+++ b/moonshine-core/src/app_scanner/heroic.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -35,14 +36,65 @@ pub struct HeroicApplicationScannerConfig {
 	pub launch_timeout_secs: u64,
 }
 
-/// Library caches written by Heroic, one per store backend: Epic (legendary),
-/// GOG (gog), Amazon (nile) and manually added games.
-const LIBRARY_FILES: [&str; 4] = [
-	"store_cache/legendary_library.json",
-	"store_cache/gog_library.json",
-	"store_cache/nile_library.json",
-	"sideload_apps/library.json",
-];
+/// Directory Heroic writes its per store library caches into.
+const STORE_CACHE_DIR: &str = "store_cache";
+
+/// Suffix Heroic gives a library cache inside [`STORE_CACHE_DIR`].
+const LIBRARY_SUFFIX: &str = "_library.json";
+
+/// Heroic's manually added games, kept outside the store cache.
+const SIDELOAD_LIBRARY: &str = "sideload_apps/library.json";
+
+/// Collect every library cache Heroic has written.
+///
+/// The store caches are discovered rather than listed, so a store backend Heroic
+/// adds later is picked up without a change here. Heroic keeps plenty besides
+/// libraries in that directory (install info, achievements, cached API
+/// responses), hence matching only on the library suffix.
+fn find_libraries(config_dir: &Path) -> Vec<PathBuf> {
+	let store_cache = config_dir.join(STORE_CACHE_DIR);
+
+	let mut libraries = match std::fs::read_dir(&store_cache) {
+		Ok(entries) => entries
+			.flatten()
+			.map(|entry| entry.path())
+			.filter(|path| {
+				path.file_name()
+					.and_then(|name| name.to_str())
+					.is_some_and(|name| name.ends_with(LIBRARY_SUFFIX))
+			})
+			.collect(),
+		Err(e) => {
+			tracing::debug!("Failed to read Heroic store cache {:?}: {e}", store_cache);
+			Vec::new()
+		},
+	};
+
+	// Directory order is arbitrary, so sort for a stable application list.
+	libraries.sort();
+
+	let sideload = config_dir.join(SIDELOAD_LIBRARY);
+	if sideload.exists() {
+		libraries.push(sideload);
+	}
+
+	libraries
+}
+
+/// Path of the manifest recording which of a store's games are installed.
+///
+/// Most stores record that in the library cache itself. GOG does not: Heroic
+/// merges install state into a copy of each game and deliberately keeps it out
+/// of the cache it writes, so every GOG entry on disk claims to be uninstalled.
+/// Reading the manifest covers that, and is the fresher source regardless, since
+/// Heroic rewrites it on every install and uninstall rather than only on a full
+/// library refresh.
+///
+/// Stores that do record install state simply have no manifest here, which reads
+/// as an empty one.
+fn installed_manifest(config_dir: &Path, runner: &str) -> PathBuf {
+	config_dir.join(format!("{runner}_store")).join("installed.json")
+}
 
 fn flatpak_config_dir() -> Option<PathBuf> {
 	Some(
@@ -114,6 +166,26 @@ struct HeroicInstall {
 	is_dlc: bool,
 }
 
+/// The contents of a store's installed games manifest.
+#[derive(Debug, Deserialize)]
+struct HeroicInstalledManifest {
+	#[serde(default)]
+	installed: Vec<HeroicInstalledGame>,
+}
+
+/// A single entry of an installed games manifest.
+#[derive(Debug, Deserialize)]
+struct HeroicInstalledGame {
+	/// Matches the `app_name` of the game's library entry.
+	///
+	/// Heroic tolerates entries without one and skips them, so this is optional.
+	#[serde(default, rename = "appName")]
+	app_name: Option<String>,
+
+	#[serde(default)]
+	is_dlc: bool,
+}
+
 pub(crate) fn scan_heroic_applications(config: &HeroicApplicationScannerConfig) -> Result<Vec<ApplicationConfig>, ()> {
 	let config_dir = &config.config_dir;
 
@@ -135,32 +207,39 @@ pub(crate) fn scan_heroic_applications(config: &HeroicApplicationScannerConfig) 
 	let mut skipped = 0;
 	let mut dlc = 0;
 
-	for library_file in LIBRARY_FILES {
-		let library_path = config_dir.join(library_file);
-		if !library_path.exists() {
-			tracing::debug!("Heroic library {:?} not found, skipping.", library_path);
-			continue;
-		}
+	// Manifests are read once per store, the first time one of its games is seen.
+	let mut installed_manifests: HashMap<String, HashMap<String, bool>> = HashMap::new();
 
+	for library_path in find_libraries(&config_dir) {
 		let games = match read_library(&library_path) {
 			Ok(games) => games,
 			Err(()) => continue,
 		};
 
 		for game in games {
-			if !game.is_installed {
+			// Sideloaded entries have no runner of their own.
+			let runner = game.runner.as_deref().unwrap_or("sideload");
+
+			if !installed_manifests.contains_key(runner) {
+				let manifest = read_installed(&installed_manifest(&config_dir, runner));
+				installed_manifests.insert(runner.to_string(), manifest);
+			}
+			let installed_entry = installed_manifests[runner].get(&game.app_name).copied();
+
+			if !game.is_installed && installed_entry.is_none() {
 				skipped += 1;
 				continue;
 			}
 
-			// DLC is launched through its base game, never on its own.
-			if game.install.is_dlc {
+			// DLC is launched through its base game, never on its own. This also
+			// drops Heroic's synthetic "Galaxy Common Redistributables" entry,
+			// the one GOG entry that is always marked installed and which it
+			// flags as DLC.
+			if game.install.is_dlc || installed_entry.unwrap_or(false) {
 				dlc += 1;
 				continue;
 			}
 
-			// Sideloaded entries have no runner of their own.
-			let runner = game.runner.as_deref().unwrap_or("sideload");
 			let boxart = find_boxart(&config_dir, &game);
 
 			let application = ApplicationConfig {
@@ -202,6 +281,35 @@ fn read_library(path: &Path) -> Result<Vec<HeroicGame>, ()> {
 	Ok(library.library)
 }
 
+/// Read a store's installed games, mapping each app name to whether it is DLC.
+///
+/// A manifest that is missing or unreadable means nothing from that store is
+/// treated as installed, which is the same outcome as before it was consulted.
+fn read_installed(path: &Path) -> HashMap<String, bool> {
+	if !path.exists() {
+		tracing::debug!("Heroic installed games manifest {:?} not found, skipping.", path);
+		return HashMap::new();
+	}
+
+	let Ok(contents) = std::fs::read_to_string(path)
+		.map_err(|e| tracing::warn!("Failed to read Heroic installed games manifest {:?}: {e}", path))
+	else {
+		return HashMap::new();
+	};
+
+	let Ok(manifest) = serde_json::from_str::<HeroicInstalledManifest>(&contents)
+		.map_err(|e| tracing::warn!("Failed to parse Heroic installed games manifest {:?}: {e}", path))
+	else {
+		return HashMap::new();
+	};
+
+	manifest
+		.installed
+		.into_iter()
+		.filter_map(|game| Some((game.app_name?, game.is_dlc)))
+		.collect()
+}
+
 /// Heroic requests Epic art through a resizing CDN and caches it under whichever
 /// URL it actually requested, so the unmodified URL is usually a miss.
 const ART_URL_VARIANTS: [&str; 3] = ["?h=800&resize=1&w=600", "?h=400&resize=1&w=300", ""];
@@ -221,13 +329,15 @@ fn is_valid_app_name(app_name: &str) -> bool {
 /// only gets used when there is nothing better.
 fn find_boxart(config_dir: &Path, game: &HeroicGame) -> Option<PathBuf> {
 	// Full resolution portrait art, saved when Heroic downloads a game icon.
+	//
+	// Heroic always writes that art as a JPG. It only writes a PNG when it has
+	// substituted a store's own icon for the art, to keep the transparency, and
+	// that icon is a small square logo rather than cover art. Matching on the
+	// extension alone keeps any store Heroic does that for out of the box art.
 	if is_valid_app_name(&game.app_name) {
-		let icons = config_dir.join("icons");
-		for extension in ["jpg", "png"] {
-			let icon = icons.join(format!("{}.{extension}", game.app_name));
-			if icon.exists() {
-				return Some(icon);
-			}
+		let icon = config_dir.join("icons").join(format!("{}.jpg", game.app_name));
+		if icon.exists() {
+			return Some(icon);
 		}
 	}
 
@@ -285,12 +395,19 @@ mod tests {
 				{"app_name": "not-installed", "title": "Uninstalled", "runner": "legendary", "is_installed": false}
 			]}"#,
 		);
+		// GOG entries are always written as uninstalled, so the manifest decides.
 		write_library(
 			config_dir,
 			"store_cache/gog_library.json",
 			r#"{"games": [
-				{"app_name": "gog-id", "title": "GOG Game", "runner": "gog", "is_installed": true}
+				{"app_name": "gog-id", "title": "GOG Game", "runner": "gog", "is_installed": false},
+				{"app_name": "gog-unowned", "title": "GOG Unowned", "runner": "gog", "is_installed": false}
 			]}"#,
+		);
+		write_library(
+			config_dir,
+			"gog_store/installed.json",
+			r#"{"installed": [{"appName": "gog-id", "is_dlc": false}]}"#,
 		);
 		write_library(
 			config_dir,
@@ -299,19 +416,41 @@ mod tests {
 				{"app_name": "amazon-id", "title": "Amazon Game", "runner": "nile", "is_installed": true}
 			]}"#,
 		);
+		// Not a store Moonshine knows about by name, but it follows the same
+		// layout, so discovery picks it up.
+		write_library(
+			config_dir,
+			"store_cache/zoom_library.json",
+			r#"{"games": [
+				{"app_name": "zoom-id", "title": "Zoom Game", "runner": "zoom", "is_installed": true}
+			]}"#,
+		);
+		write_library(
+			config_dir,
+			"sideload_apps/library.json",
+			r#"{"games": [{"app_name": "side-id", "title": "Sideloaded", "is_installed": true}]}"#,
+		);
 
 		let applications = scan_heroic_applications(&scanner_config(config_dir.to_path_buf())).unwrap();
 
+		// Store caches are scanned in name order, with sideloaded games last.
 		let titles: Vec<&str> = applications.iter().map(|app| app.title.as_str()).collect();
-		assert_eq!(titles, vec!["Epic Game", "GOG Game", "Amazon Game"]);
+		assert_eq!(
+			titles,
+			vec!["GOG Game", "Epic Game", "Amazon Game", "Zoom Game", "Sideloaded"]
+		);
 
 		assert_eq!(
 			applications[0].command,
-			vec!["/usr/bin/heroic", "heroic://launch?appName=epic-id&runner=legendary"]
+			vec!["/usr/bin/heroic", "heroic://launch?appName=gog-id&runner=gog"]
 		);
 		assert_eq!(
 			applications[1].command,
-			vec!["/usr/bin/heroic", "heroic://launch?appName=gog-id&runner=gog"]
+			vec!["/usr/bin/heroic", "heroic://launch?appName=epic-id&runner=legendary"]
+		);
+		assert_eq!(
+			applications[3].command,
+			vec!["/usr/bin/heroic", "heroic://launch?appName=zoom-id&runner=zoom"]
 		);
 	}
 
@@ -336,6 +475,56 @@ mod tests {
 
 		let titles: Vec<&str> = applications.iter().map(|app| app.title.as_str()).collect();
 		assert_eq!(titles, vec!["HITMAN 3", "No Install Block"]);
+	}
+
+	#[test]
+	fn skips_gog_games_when_the_installed_manifest_is_missing() {
+		let tempdir = tempdir().unwrap();
+		let config_dir = tempdir.path();
+
+		write_library(
+			config_dir,
+			"store_cache/gog_library.json",
+			r#"{"games": [
+				{"app_name": "gog-id", "title": "GOG Game", "runner": "gog", "is_installed": false}
+			]}"#,
+		);
+
+		let applications = scan_heroic_applications(&scanner_config(config_dir.to_path_buf())).unwrap();
+		assert!(applications.is_empty());
+	}
+
+	#[test]
+	fn skips_gog_dlc_recorded_in_the_installed_manifest() {
+		let tempdir = tempdir().unwrap();
+		let config_dir = tempdir.path();
+
+		// Heroic always prepends this synthetic entry to the GOG cache, and it is
+		// the only one it marks as installed.
+		write_library(
+			config_dir,
+			"store_cache/gog_library.json",
+			r#"{"games": [
+				{"app_name": "gog-redist", "title": "Galaxy Common Redistributables", "runner": "gog",
+				 "is_installed": true, "install": {"is_dlc": true}},
+				{"app_name": "gog-id", "title": "GOG Game", "runner": "gog", "is_installed": false},
+				{"app_name": "gog-dlc", "title": "GOG DLC", "runner": "gog", "is_installed": false}
+			]}"#,
+		);
+		write_library(
+			config_dir,
+			"gog_store/installed.json",
+			r#"{"installed": [
+				{"appName": "gog-id", "is_dlc": false},
+				{"appName": "gog-dlc", "is_dlc": true},
+				{"install_path": "/games/orphan"}
+			]}"#,
+		);
+
+		let applications = scan_heroic_applications(&scanner_config(config_dir.to_path_buf())).unwrap();
+
+		let titles: Vec<&str> = applications.iter().map(|app| app.title.as_str()).collect();
+		assert_eq!(titles, vec!["GOG Game"]);
 	}
 
 	#[test]
@@ -426,10 +615,68 @@ mod tests {
 		cache_art(config_dir, COVER_URL);
 		cache_art(config_dir, &format!("{SQUARE_URL}?h=400&resize=1&w=300"));
 
+		let icon = write_icon(config_dir, "epic-id.jpg");
+
+		assert_eq!(scan_one_boxart(config_dir), Some(icon));
+	}
+
+	fn write_gog_art_library(config_dir: &Path) {
+		write_library(
+			config_dir,
+			"store_cache/gog_library.json",
+			&format!(
+				r#"{{"games": [{{
+					"app_name": "gog-id",
+					"title": "GOG Game",
+					"runner": "gog",
+					"is_installed": false,
+					"art_square": "{SQUARE_URL}",
+					"art_cover": "{COVER_URL}"
+				}}]}}"#
+			),
+		);
+		write_library(
+			config_dir,
+			"gog_store/installed.json",
+			r#"{"installed": [{"appName": "gog-id", "is_dlc": false}]}"#,
+		);
+	}
+
+	fn write_icon(config_dir: &Path, name: &str) -> PathBuf {
 		let icons = config_dir.join("icons");
 		fs::create_dir_all(&icons).unwrap();
-		let icon = icons.join("epic-id.jpg");
+		let icon = icons.join(name);
 		fs::write(&icon, b"image").unwrap();
+		icon
+	}
+
+	#[test]
+	fn passes_over_a_substituted_store_icon_for_cover_art() {
+		let tempdir = tempdir().unwrap();
+		let config_dir = tempdir.path();
+
+		write_gog_art_library(config_dir);
+
+		// Heroic requests GOG art without the resizing parameters it adds for Epic.
+		let square_path = cache_art(config_dir, SQUARE_URL);
+
+		// A PNG under icons/ is the store's own logo, not cover art.
+		write_icon(config_dir, "gog-id.png");
+
+		assert_eq!(scan_one_boxart(config_dir), Some(square_path));
+	}
+
+	#[test]
+	fn still_uses_the_icons_entry_of_a_store_that_substitutes_icons() {
+		let tempdir = tempdir().unwrap();
+		let config_dir = tempdir.path();
+
+		write_gog_art_library(config_dir);
+		cache_art(config_dir, SQUARE_URL);
+
+		// Heroic only writes a JPG here when it had no icon to substitute, in
+		// which case it is the portrait art at full resolution.
+		let icon = write_icon(config_dir, "gog-id.jpg");
 
 		assert_eq!(scan_one_boxart(config_dir), Some(icon));
 	}

--- a/moonshine-core/src/app_scanner/heroic.rs
+++ b/moonshine-core/src/app_scanner/heroic.rs
@@ -328,21 +328,9 @@ fn is_valid_app_name(app_name: &str) -> bool {
 /// has displayed. Portrait art is preferred over the landscape banner, which
 /// only gets used when there is nothing better.
 fn find_boxart(config_dir: &Path, game: &HeroicGame) -> Option<PathBuf> {
-	// Full resolution portrait art, saved when Heroic downloads a game icon.
-	//
-	// Heroic always writes that art as a JPG. It only writes a PNG when it has
-	// substituted a store's own icon for the art, to keep the transparency, and
-	// that icon is a small square logo rather than cover art. Matching on the
-	// extension alone keeps any store Heroic does that for out of the box art.
-	if is_valid_app_name(&game.app_name) {
-		let icon = config_dir.join("icons").join(format!("{}.jpg", game.app_name));
-		if icon.exists() {
-			return Some(icon);
-		}
-	}
-
-	// Otherwise fall back to Heroic's image cache, which keys files by the
-	// SHA256 of their source URL and stores them without an extension.
+	// Heroic's image cache, which keys files by the SHA256 of their source URL
+	// and stores them without an extension. Everything its UI draws lands here,
+	// so it is the broadest source of genuine cover art.
 	let images_cache = config_dir.join("images-cache");
 	[game.art_square.as_deref(), game.art_cover.as_deref()]
 		.into_iter()
@@ -351,6 +339,21 @@ fn find_boxart(config_dir: &Path, game: &HeroicGame) -> Option<PathBuf> {
 		.flat_map(|url| ART_URL_VARIANTS.map(|variant| format!("{url}{variant}")))
 		.map(|url| images_cache.join(hex::encode(Sha256::digest(url.as_bytes()))))
 		.find(|path| path.exists())
+		.or_else(|| {
+			// Failing that, the icon Heroic saves when a game is given a desktop
+			// shortcut or added to Steam. Usually the same portrait art at full
+			// resolution, though for GOG it can be a small square store logo, so
+			// it only gets used when the cache had nothing.
+			if !is_valid_app_name(&game.app_name) {
+				return None;
+			}
+
+			let icons = config_dir.join("icons");
+			["jpg", "png"]
+				.into_iter()
+				.map(|extension| icons.join(format!("{}.{extension}", game.app_name)))
+				.find(|path| path.exists())
+		})
 }
 
 #[cfg(test)]
@@ -607,14 +610,27 @@ mod tests {
 	}
 
 	#[test]
-	fn prefers_the_full_resolution_icon_over_the_image_cache() {
+	fn prefers_cached_cover_art_over_a_shortcut_icon() {
 		let tempdir = tempdir().unwrap();
 		let config_dir = tempdir.path();
 
 		write_art_library(config_dir);
 		cache_art(config_dir, COVER_URL);
-		cache_art(config_dir, &format!("{SQUARE_URL}?h=400&resize=1&w=300"));
+		let square_path = cache_art(config_dir, &format!("{SQUARE_URL}?h=400&resize=1&w=300"));
 
+		// Heroic only writes this once a game is given a shortcut, and by then it
+		// has already cached the art the shortcut icon was downloaded from.
+		write_icon(config_dir, "epic-id.jpg");
+
+		assert_eq!(scan_one_boxart(config_dir), Some(square_path));
+	}
+
+	#[test]
+	fn falls_back_to_a_shortcut_icon_when_nothing_is_cached() {
+		let tempdir = tempdir().unwrap();
+		let config_dir = tempdir.path();
+
+		write_art_library(config_dir);
 		let icon = write_icon(config_dir, "epic-id.jpg");
 
 		assert_eq!(scan_one_boxart(config_dir), Some(icon));
@@ -660,23 +676,23 @@ mod tests {
 		// Heroic requests GOG art without the resizing parameters it adds for Epic.
 		let square_path = cache_art(config_dir, SQUARE_URL);
 
-		// A PNG under icons/ is the store's own logo, not cover art.
+		// For GOG, Heroic swaps the store's own logo in for the shortcut icon and
+		// writes it as a PNG to keep the transparency. It is a small square logo
+		// rather than cover art, so the cached art has to win.
 		write_icon(config_dir, "gog-id.png");
 
 		assert_eq!(scan_one_boxart(config_dir), Some(square_path));
 	}
 
 	#[test]
-	fn still_uses_the_icons_entry_of_a_store_that_substitutes_icons() {
+	fn falls_back_to_a_substituted_store_icon_when_nothing_is_cached() {
 		let tempdir = tempdir().unwrap();
 		let config_dir = tempdir.path();
 
 		write_gog_art_library(config_dir);
-		cache_art(config_dir, SQUARE_URL);
 
-		// Heroic only writes a JPG here when it had no icon to substitute, in
-		// which case it is the portrait art at full resolution.
-		let icon = write_icon(config_dir, "gog-id.jpg");
+		// A square store logo is poor box art, but it beats none at all.
+		let icon = write_icon(config_dir, "gog-id.png");
 
 		assert_eq!(scan_one_boxart(config_dir), Some(icon));
 	}


### PR DESCRIPTION
The Heroic scanner never returns GOG games, which is why #160 looked like only one store works.

## GOG install state

Heroic merges install state into a *copy* of each GOG game and keeps that copy out of the library cache it writes to disk, in `storeManagers/gog/library.ts`:

```js
// Create new object to not write install data into library store
const copyObject = Object.assign({}, unifiedObject)
if (installedInfo) {
  copyObject.is_installed = true
  copyObject.install = installedInfo
}
library.set(copyObject.app_name, copyObject)   // in-memory only
...
libraryStore.set('games', gamesObjects)        // disk, without install state
```

`gogToUnifiedInfo` hardcodes `is_installed: false`, so every entry in `store_cache/gog_library.json` claims to be uninstalled and the scanner drops the lot. Epic, Amazon and sideloaded entries record install state in their own caches, so only GOG is affected. Same behavior back through v2.14.0, so it isn't a recent regression.

Fall back to `<runner>_store/installed.json`, keyed by `appName` to match the library entry's `app_name`. Heroic rewrites it on every install and uninstall rather than only on a full library refresh, so it's fresher than the cache would have been either way. A missing manifest reads as empty, so stores that report `is_installed` honestly are unaffected.

The library flag is still honored alongside the manifest. That keeps the synthetic `gog-redist` entry, the one GOG game Heroic always marks installed, going through the existing DLC filter that already hides "Galaxy Common Redistributables".

## Library discovery

The four library paths were hardcoded. They're now discovered by suffix under `store_cache/`, plus `sideload_apps/library.json`. That directory holds plenty besides libraries (install info, achievements, cached API responses), so only `*_library.json` is matched.

This picks up **Zoom Platform**, the fifth backend Heroic shipped in v2.22, which wasn't being scanned at all. A sixth needs no change here. The runner already comes from the library entry, so the installed manifest path follows from it rather than needing its own table.

## Box art

`icons/<app_name>.png` was being preferred over the real cover art. `shortcuts/utils.ts::getIcon` writes the portrait art it downloads as `.jpg` for every store, and only writes a `.png` when it has substituted a store's own icon to keep transparency:

```js
if (productApiData && productApiData.data.images?.icon) {
  image = 'https:' + productApiData.data.images?.icon
  icon = `${iconsFolder}/${appName}.png` // Allow transparency
}
```

That icon is a square logo, not cover art. GOG is the only backend it happens for today, so matching on the extension rather than the runner covers any other it starts happening for. GOG art is cached under the unmodified `art_square` URL, since `getImageFormatting` only appends the resizing parameters for Epic, so the existing image cache lookup finds it.

## Testing

Unit tests cover each of the above. Also checked against a real Heroic config with 47 Epic entries: discovery finds the three caches and the scan returns the 3 installed non-DLC games with their `icons/*.jpg` art, unchanged from before.

I don't own any GOG, Amazon or Zoom games, so those paths are verified against Heroic's source rather than a live library. @istvnurbn confirmed the GOG fix works on their setup, and reported the box art problem that the last section fixes.

Fixes #160
