### PR TITLE
fix: use fail mode for Plasma sessions to avoid systemd reload conflict

### DIFF
--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -109,6 +109,7 @@ pub(crate) struct LaunchOptions<'a> {
 	pub post_commands: &'a Vec<Vec<String>>,
 	pub stdout_value: &'a Option<String>,
 	pub stderr_value: &'a Option<String>,
+	pub job_mode: &'static str,
 }
 
 /// Runtime context required to launch an application.
@@ -157,6 +158,8 @@ impl Application {
 		// Stop any leftover unit from a previous session.
 		let _ = stop_unit(&conn, &context.unit_name).await;
 
+		let job_mode = if is_plasma_session(program) { "fail" } else { "replace" };
+
 		// Launch the application as a transient systemd service unit.
 		let options = LaunchOptions {
 			unit_name: &context.unit_name,
@@ -168,6 +171,7 @@ impl Application {
 			post_commands: &config.post_command,
 			stdout_value: &config.stdout,
 			stderr_value: &config.stderr,
+			job_mode,
 		};
 
 		let unit_path = match start_transient_service(&conn, &options).await {
@@ -204,6 +208,11 @@ impl Drop for Application {
 		.join()
 		.unwrap();
 	}
+}
+
+fn is_plasma_session(program: &str) -> bool {
+	let name = program.split('/').next_back().unwrap_or(program);
+	matches!(name, "startplasma-way" | "startplasma-wayland" | "plasmashell")
 }
 
 /// Build environment variables for the application based on the context (e.g. display, PulseAudio socket).
@@ -621,7 +630,7 @@ async fn start_transient_service(conn: &Connection, options: &LaunchOptions<'_>)
 			SYSTEMD_PATH,
 			Some(SYSTEMD_MANAGER),
 			"StartTransientUnit",
-			&(options.unit_name, "replace", &properties, &aux),
+			&(options.unit_name, options.job_mode, &properties, &aux),
 		)
 		.await
 		.map_err(|e| tracing::warn!("Failed to start transient service: {e}"))?;
@@ -758,7 +767,7 @@ fn build_exec_array(entries: &[(String, Vec<String>, bool)]) -> Result<zvariant:
 
 #[cfg(test)]
 mod tests {
-	use super::split_standard_io;
+	use super::{is_plasma_session, split_standard_io};
 
 	#[test]
 	fn test_standard_io_defaults_to_null() {
@@ -813,5 +822,21 @@ mod tests {
 			split_standard_io(&Some("fd:stdout".to_string())),
 			("fd".to_string(), Some(("FileDescriptorName", "stdout".to_string())))
 		);
+	}
+
+	#[test]
+	fn test_is_plasma_session_detects_plasma_binaries() {
+		assert!(is_plasma_session("/usr/bin/startplasma-way"));
+		assert!(is_plasma_session("/usr/bin/startplasma-wayland"));
+		assert!(is_plasma_session("/usr/bin/plasmashell"));
+		assert!(is_plasma_session("startplasma-way"));
+	}
+
+	#[test]
+	fn test_is_plasma_session_ignores_non_plasma() {
+		assert!(!is_plasma_session("/usr/bin/steam"));
+		assert!(!is_plasma_session("/usr/bin/wine"));
+		assert!(!is_plasma_session("/usr/bin/xdg-open"));
+		assert!(!is_plasma_session("cosmic-session"));
 	}
 }

--- a/moonshine-core/src/session/compositor/state.rs
+++ b/moonshine-core/src/session/compositor/state.rs
@@ -45,6 +45,7 @@ use smithay::wayland::relative_pointer::RelativePointerManagerState;
 use smithay::wayland::selection::data_device::DataDeviceState;
 use smithay::wayland::shell::xdg::XdgShellState;
 use smithay::wayland::shm::ShmState;
+use smithay::wayland::single_pixel_buffer::SinglePixelBufferState;
 use smithay::wayland::socket::ListeningSocketSource;
 use smithay::wayland::xwayland_shell::XWaylandShellState;
 use smithay::xwayland::X11Wm;
@@ -251,6 +252,9 @@ pub(crate) struct MoonshineCompositor {
 	/// Monotonically increasing render counter.
 	pub render_count: usize,
 
+	// -- Single-pixel buffer --
+	pub single_pixel_buffer_state: SinglePixelBufferState,
+
 	// -- Static screen detection --
 	/// Set to `true` whenever visible content changes (surface commit, cursor
 	/// move). Cleared after a frame is sent. When false and a frame was sent
@@ -445,6 +449,7 @@ impl MoonshineCompositor {
 		RelativePointerManagerState::new::<Self>(&display_handle);
 		PointerConstraintsState::new::<Self>(&display_handle);
 		let viewporter_state = smithay::wayland::viewporter::ViewporterState::new::<Self>(&display_handle);
+		let single_pixel_buffer_state = SinglePixelBufferState::new::<Self>(&display_handle);
 		smithay::wayland::presentation::PresentationState::new::<Self>(&display_handle, 1);
 		let clock = Clock::new();
 
@@ -598,6 +603,7 @@ impl MoonshineCompositor {
 				last_frame_sent_at: std::time::Instant::now(),
 				last_cursor_position: Point::from((width as f64 / 2.0, height as f64 / 2.0)),
 				viewporter_state,
+				single_pixel_buffer_state,
 				color_management,
 				deferred_info_done: Vec::new(),
 				xwayland_shell_state,


### PR DESCRIPTION
When streaming a KDE Plasma desktop session, the Plasma session startup fails with:

> Could not start systemd managed Plasma session: "org.freedesktop.systemd1.TransactionIsDestructive"

## What happened

The journal logs show the sequence:

1. `moonshine` calls `StartTransientUnit("moonshine-session.service", "replace", ...)`
2. The `"replace"` mode triggers a systemd reload of the transient unit
3. Plasma's systemd integration (which monitors the transient unit it runs in) interprets the reload as a session teardown signal
4. Plasma tries to tear down `graphical-session.target` while simultaneously starting `plasma-workspace-wayland.target`
5. systemd rejects this as a destructive transaction conflict

## Why this fix works

Plasma's systemd integration reacts to the reload triggered by `"replace"` mode. Using `"fail"` mode avoids the reload entirely — it simply fails if the unit already exists. Since `stop_unit` is always called beforehand to clean up leftover units, `"fail"` mode never actually fails in practice.

The fix is conditional: only Plasma desktop sessions (`startplasma-way`, `startplasma-wayland`, `plasmashell`) use `"fail"` mode. All other sessions (games, Steam, etc.) continue using `"replace"` with no behavior change.

## Related: SinglePixelBufferState

Added `SinglePixelBufferState` to the compositor state. This enables the single-pixel buffer protocol for Wayland clients that require it (e.g. certain GTK4 UI elements).

## Testing

- All CI checks pass: fmt, clippy, tests (93), docs, machete
- Tested with KDE Plasma desktop stream — no more transaction conflict