### PR TITLE
update nix section with newly added module and pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ nix profile install github:hgaiser/moonshine
 
 After installing, follow the [Enable the service](#enable-the-service) steps below (the NixOS module handles this for you when enabled).
 
+Moonshine is now directly packaged in nixpkgs, you can add it to your system packages or enable the module directly:
+
+```nix
+environment.systemPackages = with pkgs; [ moonshine ];
+services.moonshine = {
+	enable = true;
+	# Checkout more settings at https://search.nixos.org/options?query=moonshine
+};
+```
+
 ### Bazzite / Silverblue / Atomic distros
 
 On Fedora Atomic distros, download the `.rpm` from the [releases page](https://github.com/hgaiser/moonshine/releases) and layer it:


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/544596 got merged into nixpkgs last month with the the pkg already existing in unstable [PR tracker](https://nixpk.gs/pr-tracker.html?pr=544596).  
There is also a module init pr https://github.com/NixOS/nixpkgs/pull/544393, however its still not merged. I will open this as draft until that is merged.

I wonder if its best to leave the existing instructions on how to use this project's consumable module or to delete them and the module file.