### PR TITLE
fix: dont name an unknown pa source

### DIFF
--- a/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
+++ b/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
@@ -210,7 +210,7 @@ impl PulseServer {
 			server_version: Some(std::ffi::CString::new(env!("CARGO_PKG_VERSION")).unwrap()),
 			host_name: Some(std::ffi::CString::new("moonshine").unwrap()),
 			default_sink_name: Some(sink_name.clone()),
-			default_source_name: Some(sink_name),
+			default_source_name: None,
 			sample_spec: capture_spec,
 			channel_map,
 			..Default::default()


### PR DESCRIPTION
Specifying a default_source_name causes issues for apps that will then try to use that source, since there is no server implementation for audio sources yet.

Caused the Project Zomboid native linux client to crash in libfmod.so