### PR TITLE
feat: add native touch and pen input

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Your keyboard, mouse, and controller inputs are sent back to the host so you can
 - **No monitor required**: Works on headless servers — no HDMI dummy plug needed.
 - **Hardware video encoding**: H.264, H.265, and AV1 encoding using the GPU.
 - **HDR support**: True 10-bit HDR streaming for supported games.
-- **Full input support**: Mouse, keyboard, and gamepad (including motion, touchpad, and haptics).
+- **Full input support**: Mouse, keyboard, touchscreen, pen/stylus, and gamepad (including motion, touchpad, and haptics).
 - **Audio streaming**: Stereo and surround sound (5.1/7.1) with low-latency Opus encoding.
 
 ## Requirements

--- a/moonshine-core/src/rtsp.rs
+++ b/moonshine-core/src/rtsp.rs
@@ -26,7 +26,7 @@ use crate::session::stream::video::VideoStreamContext;
 
 #[repr(u8)]
 enum ServerCapabilities {
-	_TouchEvents = 0x01,
+	PenTouchEvents = 0x01,
 	ControllerTouchEvents = 0x02,
 }
 
@@ -114,7 +114,7 @@ impl RtspServer {
 	}
 
 	fn capabilities(&self) -> u8 {
-		ServerCapabilities::ControllerTouchEvents as u8
+		ServerCapabilities::PenTouchEvents as u8 | ServerCapabilities::ControllerTouchEvents as u8
 	}
 
 	fn encryption_flags_supported(&self) -> u8 {

--- a/moonshine-core/src/session/compositor/handlers.rs
+++ b/moonshine-core/src/session/compositor/handlers.rs
@@ -5,6 +5,7 @@
 
 use smithay::backend::allocator::Buffer;
 use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::input::TabletToolDescriptor;
 use smithay::backend::renderer::ImportDma;
 use smithay::backend::renderer::utils::on_commit_buffer_handler;
 use smithay::delegate_dispatch2;
@@ -29,6 +30,7 @@ use smithay::wayland::selection::SelectionHandler;
 use smithay::wayland::selection::data_device::{DataDeviceHandler, DataDeviceState, WaylandDndGrabHandler};
 use smithay::wayland::shell::xdg::{PopupSurface, PositionerState, ToplevelSurface, XdgShellHandler, XdgShellState};
 use smithay::wayland::shm::{ShmHandler, ShmState};
+use smithay::wayland::tablet_manager::TabletSeatHandler;
 use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
 use smithay::xwayland::xwm::{Reorder, ResizeEdge, XwmId};
 use smithay::xwayland::{X11Surface, X11Wm, XwmHandler};
@@ -1539,6 +1541,12 @@ impl SeatHandler for MoonshineCompositor {
 	}
 
 	fn led_state_changed(&mut self, _seat: &Seat<Self>, _led_state: smithay::input::keyboard::LedState) {}
+}
+
+impl TabletSeatHandler for MoonshineCompositor {
+	fn tablet_tool_image(&mut self, _tool: &TabletToolDescriptor, image: CursorImageStatus) {
+		self.cursor_status = image;
+	}
 }
 
 // -- Selection / Data Device Handlers --

--- a/moonshine-core/src/session/compositor/input.rs
+++ b/moonshine-core/src/session/compositor/input.rs
@@ -4,12 +4,16 @@
 //! via a `calloop::channel`. The compositor injects them directly into the
 //! Smithay `Seat` — no libei or EIS socket needed.
 
-use smithay::backend::input::{Axis, ButtonState, KeyState};
+use smithay::backend::input::{
+	Axis, ButtonState, KeyState, TabletToolCapabilities, TabletToolDescriptor, TabletToolType, TouchSlot,
+};
 use smithay::desktop::WindowSurfaceType;
 use smithay::input::keyboard::{FilterResult, Keycode};
 use smithay::input::pointer::{AxisFrame, ButtonEvent, MotionEvent, RelativeMotionEvent};
+use smithay::input::touch::{DownEvent as TouchDownEvent, MotionEvent as TouchMotionEvent, UpEvent as TouchUpEvent};
 use smithay::utils::{Logical, Point, SERIAL_COUNTER};
 use smithay::wayland::pointer_constraints::{PointerConstraint, with_pointer_constraint};
+use smithay::wayland::tablet_manager::{TabletSeatTrait, TabletToolHandle};
 
 use crate::session::compositor::state::MoonshineCompositor;
 
@@ -21,9 +25,13 @@ use crate::session::compositor::state::MoonshineCompositor;
 #[derive(Debug)]
 pub(crate) enum CompositorInputEvent {
 	/// A key was pressed. `keycode` is a Linux evdev keycode.
-	KeyDown { keycode: u32 },
+	KeyDown {
+		keycode: u32,
+	},
 	/// A key was released. `keycode` is a Linux evdev keycode.
-	KeyUp { keycode: u32 },
+	KeyUp {
+		keycode: u32,
+	},
 	/// Absolute pointer motion. Coordinates are in pixels relative to the
 	/// Moonlight client's screen dimensions.
 	MouseMoveAbsolute {
@@ -33,15 +41,52 @@ pub(crate) enum CompositorInputEvent {
 		screen_height: i16,
 	},
 	/// Relative pointer motion in pixels.
-	MouseMoveRelative { dx: i16, dy: i16 },
+	MouseMoveRelative {
+		dx: i16,
+		dy: i16,
+	},
 	/// A mouse button was pressed. `button` is a Linux button code (e.g. BTN_LEFT = 0x110).
-	MouseButtonDown { button: u32 },
+	MouseButtonDown {
+		button: u32,
+	},
 	/// A mouse button was released.
-	MouseButtonUp { button: u32 },
+	MouseButtonUp {
+		button: u32,
+	},
 	/// Vertical scroll. Positive = scroll up, negative = scroll down.
-	ScrollVertical { amount: i16 },
+	ScrollVertical {
+		amount: i16,
+	},
 	/// Horizontal scroll.
-	ScrollHorizontal { amount: i16 },
+	ScrollHorizontal {
+		amount: i16,
+	},
+	/// Native touchscreen contact in normalized video coordinates.
+	TouchDown {
+		slot: u32,
+		x: f32,
+		y: f32,
+	},
+	TouchMove {
+		slot: u32,
+		x: f32,
+		y: f32,
+	},
+	TouchUp {
+		slot: u32,
+	},
+	TouchCancelAll,
+	/// Native pen input in normalized video coordinates.
+	Pen {
+		event_kind: u8,
+		tool_kind: u8,
+		buttons: u8,
+		x: f32,
+		y: f32,
+		pressure_or_distance: f32,
+		rotation: u16,
+		tilt: u8,
+	},
 }
 
 /// Process an input event received from the Moonlight control stream.
@@ -55,7 +100,12 @@ pub(crate) fn process_input(event: CompositorInputEvent, state: &mut MoonshineCo
 
 	// specific pointer events (non-keyboard) should reset the cursor inactivity timer
 	match event {
-		CompositorInputEvent::KeyDown { .. } | CompositorInputEvent::KeyUp { .. } => {},
+		CompositorInputEvent::KeyDown { .. }
+		| CompositorInputEvent::KeyUp { .. }
+		| CompositorInputEvent::TouchDown { .. }
+		| CompositorInputEvent::TouchMove { .. }
+		| CompositorInputEvent::TouchUp { .. }
+		| CompositorInputEvent::TouchCancelAll => {},
 		_ => state.last_pointer_activity = Some(std::time::Instant::now()),
 	}
 
@@ -233,7 +283,248 @@ pub(crate) fn process_input(event: CompositorInputEvent, state: &mut MoonshineCo
 			);
 			pointer.frame(state);
 		},
+		CompositorInputEvent::TouchDown { slot, x, y } => {
+			let location = normalized_pointer_location(state, x, y);
+			let under = find_surface_at(state, location);
+			if let Some(touch) = state.seat.get_touch() {
+				touch.down(
+					state,
+					under,
+					&TouchDownEvent {
+						slot: TouchSlot::from(Some(slot)),
+						location,
+						serial,
+						time,
+					},
+				);
+				touch.frame(state);
+			}
+		},
+		CompositorInputEvent::TouchMove { slot, x, y } => {
+			let location = normalized_pointer_location(state, x, y);
+			let under = find_surface_at(state, location);
+			if let Some(touch) = state.seat.get_touch() {
+				touch.motion(
+					state,
+					under,
+					&TouchMotionEvent {
+						slot: TouchSlot::from(Some(slot)),
+						location,
+						time,
+					},
+				);
+				touch.frame(state);
+			}
+		},
+		CompositorInputEvent::TouchUp { slot } => {
+			if let Some(touch) = state.seat.get_touch() {
+				touch.up(
+					state,
+					&TouchUpEvent {
+						slot: TouchSlot::from(Some(slot)),
+						serial,
+						time,
+					},
+				);
+				touch.frame(state);
+			}
+		},
+		CompositorInputEvent::TouchCancelAll => {
+			if let Some(touch) = state.seat.get_touch() {
+				touch.cancel(state);
+			}
+		},
+		CompositorInputEvent::Pen {
+			event_kind,
+			tool_kind,
+			buttons,
+			x,
+			y,
+			pressure_or_distance,
+			rotation,
+			tilt,
+		} => process_pen_input(
+			state,
+			PenInput {
+				event_kind,
+				tool_kind,
+				buttons,
+				x,
+				y,
+				pressure_or_distance,
+				rotation,
+				tilt,
+			},
+			serial,
+			time,
+		),
 	}
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PenInput {
+	event_kind: u8,
+	tool_kind: u8,
+	buttons: u8,
+	x: f32,
+	y: f32,
+	pressure_or_distance: f32,
+	rotation: u16,
+	tilt: u8,
+}
+
+const POINTER_EVENT_HOVER: u8 = 0x00;
+const POINTER_EVENT_DOWN: u8 = 0x01;
+const POINTER_EVENT_UP: u8 = 0x02;
+const POINTER_EVENT_MOVE: u8 = 0x03;
+const POINTER_EVENT_CANCEL: u8 = 0x04;
+const POINTER_EVENT_BUTTON_ONLY: u8 = 0x05;
+const POINTER_EVENT_HOVER_LEAVE: u8 = 0x06;
+const POINTER_EVENT_CANCEL_ALL: u8 = 0x07;
+
+const PEN_TOOL_ERASER: u8 = 0x02;
+const ROTATION_UNKNOWN: u16 = 0xFFFF;
+const TILT_UNKNOWN: u8 = 0xFF;
+
+fn pen_tool_descriptor(tool_kind: u8) -> TabletToolDescriptor {
+	let is_eraser = tool_kind == PEN_TOOL_ERASER;
+	TabletToolDescriptor {
+		tool_type: if is_eraser {
+			TabletToolType::Eraser
+		} else {
+			TabletToolType::Pen
+		},
+		hardware_serial: u64::from(tool_kind),
+		hardware_id_wacom: 0,
+		capabilities: TabletToolCapabilities::PRESSURE
+			| TabletToolCapabilities::DISTANCE
+			| TabletToolCapabilities::TILT,
+	}
+}
+
+fn get_pen_tool(state: &mut MoonshineCompositor, tool_kind: u8) -> TabletToolHandle {
+	let tablet_seat = state.seat.tablet_seat();
+	let descriptor = pen_tool_descriptor(tool_kind);
+	if let Some(tool) = tablet_seat.get_tool(&descriptor) {
+		return tool;
+	}
+
+	let display_handle = state.display_handle.clone();
+	tablet_seat.add_tool::<MoonshineCompositor>(state, &display_handle, &descriptor)
+}
+
+fn release_pen(state: &mut MoonshineCompositor, time: u32) {
+	let Some(tool_kind) = state.active_pen_tool_kind.take() else {
+		state.pen_buttons = 0;
+		return;
+	};
+
+	if let Some(tool) = state.seat.tablet_seat().get_tool(&pen_tool_descriptor(tool_kind)) {
+		tool.tip_up(time);
+		sync_pen_buttons(&tool, state.pen_buttons, 0, time);
+		tool.proximity_out(time);
+	}
+	state.pen_buttons = 0;
+}
+
+fn sync_pen_buttons(tool: &TabletToolHandle, old_buttons: u8, new_buttons: u8, time: u32) {
+	const BUTTONS: [(u8, u32); 3] = [
+		(0x01, 0x14B), // BTN_STYLUS
+		(0x02, 0x14C), // BTN_STYLUS2
+		(0x04, 0x149), // BTN_STYLUS3
+	];
+
+	for (mask, button) in BUTTONS {
+		if old_buttons & mask != new_buttons & mask {
+			let state = if new_buttons & mask != 0 {
+				ButtonState::Pressed
+			} else {
+				ButtonState::Released
+			};
+			tool.button(button, state, SERIAL_COUNTER.next_serial(), time);
+		}
+	}
+}
+
+fn process_pen_input(state: &mut MoonshineCompositor, event: PenInput, serial: smithay::utils::Serial, time: u32) {
+	if matches!(
+		event.event_kind,
+		POINTER_EVENT_CANCEL | POINTER_EVENT_HOVER_LEAVE | POINTER_EVENT_CANCEL_ALL
+	) {
+		release_pen(state, time);
+		return;
+	}
+
+	if event.event_kind == POINTER_EVENT_BUTTON_ONLY {
+		if let Some(tool_kind) = state.active_pen_tool_kind {
+			let tool = get_pen_tool(state, tool_kind);
+			sync_pen_buttons(&tool, state.pen_buttons, event.buttons, time);
+			state.pen_buttons = event.buttons;
+		}
+		return;
+	}
+
+	if state
+		.active_pen_tool_kind
+		.is_some_and(|active| active != event.tool_kind)
+	{
+		release_pen(state, time);
+	}
+
+	let tool = get_pen_tool(state, event.tool_kind);
+	let tablet_seat = state.seat.tablet_seat();
+	let Some(tablet) = tablet_seat.get_tablet(&state.pen_tablet_descriptor) else {
+		return;
+	};
+	let location = normalized_pointer_location(state, event.x, event.y);
+	let focus = find_surface_at(state, location);
+	state.cursor_position = location;
+
+	if state.active_pen_tool_kind.is_none() {
+		let Some(focus) = focus.clone() else {
+			return;
+		};
+		tool.proximity_in(location, focus, &tablet, serial, time);
+		state.active_pen_tool_kind = Some(event.tool_kind);
+	}
+
+	let value = event.pressure_or_distance.clamp(0.0, 1.0) as f64;
+	if event.event_kind == POINTER_EVENT_HOVER {
+		tool.distance(value);
+	} else {
+		tool.pressure(value);
+	}
+
+	if event.rotation != ROTATION_UNKNOWN && event.tilt != TILT_UNKNOWN {
+		let angle = (event.rotation as f64).to_radians();
+		let magnitude = f64::from(event.tilt.min(90));
+		tool.tilt((magnitude * angle.sin(), -magnitude * angle.cos()));
+	}
+
+	tool.motion(location, focus, &tablet, serial, time);
+	sync_pen_buttons(&tool, state.pen_buttons, event.buttons, time);
+	state.pen_buttons = event.buttons;
+
+	match event.event_kind {
+		POINTER_EVENT_DOWN | POINTER_EVENT_MOVE => {
+			tool.tip_down(SERIAL_COUNTER.next_serial(), time);
+		},
+		POINTER_EVENT_UP => {
+			tool.tip_up(time);
+		},
+		_ => {},
+	}
+}
+
+fn normalized_pointer_location(state: &MoonshineCompositor, x: f32, y: f32) -> Point<f64, Logical> {
+	let output_size = state
+		.output
+		.current_mode()
+		.map(|mode| mode.size)
+		.unwrap_or((state.width as i32, state.height as i32).into());
+	let max_x = output_size.w.saturating_sub(1).max(0) as f64;
+	let max_y = output_size.h.saturating_sub(1).max(0) as f64;
+	Point::from((x.clamp(0.0, 1.0) as f64 * max_x, y.clamp(0.0, 1.0) as f64 * max_y))
 }
 
 /// Clamp the cursor position to the output bounds, expanded to include
@@ -290,6 +581,16 @@ fn find_surface_under(
 	<MoonshineCompositor as smithay::input::SeatHandler>::PointerFocus,
 	Point<f64, Logical>,
 )> {
+	find_surface_at(state, state.cursor_position)
+}
+
+fn find_surface_at(
+	state: &MoonshineCompositor,
+	position: Point<f64, Logical>,
+) -> Option<(
+	<MoonshineCompositor as smithay::input::SeatHandler>::PointerFocus,
+	Point<f64, Logical>,
+)> {
 	// Priority 1: Override window (dropdown) is active — route to it.
 	// Only do this when the WSI bypass surface is NOT active.  When
 	// override_surface is active the renderer replaces the entire space
@@ -300,7 +601,7 @@ fn find_surface_under(
 		&& let Some(ref override_win) = state.override_window
 	{
 		let override_loc = state.space.element_geometry(override_win)?.loc;
-		let pos_within_override = state.cursor_position - override_loc.to_f64();
+		let pos_within_override = position - override_loc.to_f64();
 		if let Some((surface, surface_offset)) = override_win.surface_under(pos_within_override, WindowSurfaceType::ALL)
 		{
 			return Some((surface, surface_offset.to_f64() + override_loc.to_f64()));
@@ -316,7 +617,7 @@ fn find_surface_under(
 					&& x11.window_id() == wid
 				{
 					let window_loc = state.space.element_geometry(window)?.loc;
-					let pos_within_window = state.cursor_position - window_loc.to_f64();
+					let pos_within_window = position - window_loc.to_f64();
 					// Try finding a sub-surface under the cursor first.
 					if let Some((surface, surface_offset)) =
 						window.surface_under(pos_within_window, WindowSurfaceType::ALL)
@@ -344,8 +645,8 @@ fn find_surface_under(
 	}
 
 	// Priority 3: Normal cursor-based surface finding.
-	let (window, window_loc) = state.space.element_under(state.cursor_position)?;
-	let pos_within_window = state.cursor_position - window_loc.to_f64();
+	let (window, window_loc) = state.space.element_under(position)?;
+	let pos_within_window = position - window_loc.to_f64();
 	let (surface, surface_offset) = window.surface_under(pos_within_window, WindowSurfaceType::ALL)?;
 	Some((surface, surface_offset.to_f64() + window_loc.to_f64()))
 }

--- a/moonshine-core/src/session/compositor/state.rs
+++ b/moonshine-core/src/session/compositor/state.rs
@@ -46,6 +46,7 @@ use smithay::wayland::selection::data_device::DataDeviceState;
 use smithay::wayland::shell::xdg::XdgShellState;
 use smithay::wayland::shm::ShmState;
 use smithay::wayland::socket::ListeningSocketSource;
+use smithay::wayland::tablet_manager::{TabletDescriptor, TabletManagerState, TabletSeatTrait};
 use smithay::wayland::xwayland_shell::XWaylandShellState;
 use smithay::xwayland::X11Wm;
 
@@ -226,6 +227,9 @@ pub(crate) struct MoonshineCompositor {
 	pub cursor_status: CursorImageStatus,
 	pub pointer_element: PointerElement,
 	pub last_pointer_activity: Option<std::time::Instant>,
+	pub pen_tablet_descriptor: TabletDescriptor,
+	pub active_pen_tool_kind: Option<u8>,
+	pub pen_buttons: u8,
 
 	// -- Desktop --
 	pub space: Space<smithay::desktop::Window>,
@@ -444,6 +448,7 @@ impl MoonshineCompositor {
 		let xwayland_shell_state = XWaylandShellState::new::<Self>(&display_handle);
 		RelativePointerManagerState::new::<Self>(&display_handle);
 		PointerConstraintsState::new::<Self>(&display_handle);
+		TabletManagerState::new::<Self>(&display_handle);
 		let viewporter_state = smithay::wayland::viewporter::ViewporterState::new::<Self>(&display_handle);
 		smithay::wayland::presentation::PresentationState::new::<Self>(&display_handle, 1);
 		let clock = Clock::new();
@@ -468,11 +473,19 @@ impl MoonshineCompositor {
 
 		let mut space = Space::default();
 
-		// Create seat with keyboard and pointer.
+		// Create the input devices exposed to streamed applications.
 		let mut seat = seat_state.new_wl_seat(&display_handle, "moonshine");
 		seat.add_keyboard(xkb_config, 200, 25)
 			.expect("Failed to add keyboard to seat");
 		seat.add_pointer();
+		seat.add_touch();
+		let pen_tablet_descriptor = TabletDescriptor {
+			name: "Moonlight Pen".to_owned(),
+			usb_id: None,
+			syspath: None,
+		};
+		seat.tablet_seat()
+			.add_tablet::<Self>(&display_handle, &pen_tablet_descriptor);
 
 		// Create the Wayland socket for clients to connect.
 		let socket_source = ListeningSocketSource::new_auto().expect("Failed to create Wayland listening socket");
@@ -583,6 +596,9 @@ impl MoonshineCompositor {
 				cursor_status: CursorImageStatus::default_named(),
 				pointer_element,
 				last_pointer_activity: None,
+				pen_tablet_descriptor,
+				active_pen_tool_kind: None,
+				pen_buttons: 0,
 				space,
 				clock,
 				handle,

--- a/moonshine-core/src/session/stream/control/input/keyboard.rs
+++ b/moonshine-core/src/session/stream/control/input/keyboard.rs
@@ -150,7 +150,21 @@ impl Key {
 			return Err(());
 		}
 
-		Key::from_repr(buffer[1]).ok_or_else(|| tracing::warn!("Unknown keycode: {}", buffer[5]))
+		let wire_keycode = u16::from_le_bytes(buffer[1..3].try_into().unwrap());
+		let keycode = (wire_keycode & 0x00FF) as u8;
+
+		// Some clients emit null or unmapped keyboard packets while handling
+		// touch input. They do not represent a key and must not flood the logs.
+		if matches!(keycode, 0x00 | 0xFF) {
+			return Err(());
+		}
+
+		Key::from_repr(keycode).ok_or_else(|| {
+			tracing::warn!(
+				wire_keycode = format_args!("0x{wire_keycode:04X}"),
+				"Unsupported keyboard keycode"
+			)
+		})
 	}
 
 	/// Convert a Windows virtual key code to a Linux evdev keycode.
@@ -263,5 +277,28 @@ impl Key {
 			Key::NonUsBackslash => Some(86),
 			_ => None,
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Key;
+
+	#[test]
+	fn parses_normalized_keyboard_keycode() {
+		let payload = [0x00, Key::A as u8, 0x80, 0x00, 0x00, 0x00];
+		assert_eq!(Key::from_bytes(&payload), Ok(Key::A));
+	}
+
+	#[test]
+	fn ignores_null_keyboard_keycode() {
+		let payload = [0x00, 0x00, 0x80, 0x00, 0x00, 0x00];
+		assert_eq!(Key::from_bytes(&payload), Err(()));
+	}
+
+	#[test]
+	fn ignores_unmapped_keyboard_keycode() {
+		let payload = [0x00, 0xFF, 0x00, 0x00, 0x00, 0x00];
+		assert_eq!(Key::from_bytes(&payload), Err(()));
 	}
 }

--- a/moonshine-core/src/session/stream/control/input/mod.rs
+++ b/moonshine-core/src/session/stream/control/input/mod.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc;
 use self::gamepad::Gamepad;
 use self::gamepad::GamepadConfig;
 use self::remap::{HoldToHome, HoldTransition};
+use self::touch::{Pen, PointerEventKind, Touch};
 use crate::session::compositor::input::CompositorInputEvent;
 use crate::session::manager::SessionShutdownReason;
 
@@ -25,6 +26,7 @@ pub(crate) mod gamepad;
 mod keyboard;
 mod mouse;
 mod remap;
+mod touch;
 
 #[derive(FromRepr)]
 #[repr(u32)]
@@ -37,6 +39,8 @@ enum InputEventType {
 	MouseButtonUp = 0x00000009,
 	MouseScrollVertical = 0x0000000A,
 	MouseScrollHorizontal = 0x55000001,
+	Touch = 0x55000002,
+	Pen = 0x55000003,
 	GamepadInfo = 0x55000004, // Called ControllerArrival in Moonlight.
 	GamepadTouch = 0x55000005,
 	GamepadMotion = 0x55000006,
@@ -56,6 +60,8 @@ enum InputEvent {
 	MouseButtonUp(MouseButton),
 	MouseScrollVertical(MouseScrollVertical),
 	MouseScrollHorizontal(MouseScrollHorizontal),
+	Touch(Touch),
+	Pen(Pen),
 	GamepadInfo(GamepadInfo),
 	GamepadTouch(GamepadTouch),
 	GamepadMotion(GamepadMotion),
@@ -96,6 +102,8 @@ impl InputEvent {
 			Some(InputEventType::MouseScrollHorizontal) => Ok(InputEvent::MouseScrollHorizontal(
 				MouseScrollHorizontal::from_bytes(&buffer[4..])?,
 			)),
+			Some(InputEventType::Touch) => Ok(InputEvent::Touch(Touch::from_bytes(&buffer[4..])?)),
+			Some(InputEventType::Pen) => Ok(InputEvent::Pen(Pen::from_bytes(&buffer[4..])?)),
 			Some(InputEventType::GamepadInfo) => Ok(InputEvent::GamepadInfo(GamepadInfo::from_bytes(&buffer[4..])?)),
 			Some(InputEventType::GamepadTouch) => Ok(InputEvent::GamepadTouch(GamepadTouch::from_bytes(&buffer[4..])?)),
 			Some(InputEventType::GamepadMotion) => {
@@ -203,6 +211,42 @@ impl InputHandler {
 				let _ = self
 					.input_tx
 					.send(CompositorInputEvent::ScrollHorizontal { amount: event.amount });
+			},
+			InputEvent::Touch(event) => {
+				tracing::trace!("Touch input: {event:?}");
+				let compositor_event = match event.event_kind {
+					PointerEventKind::Down => Some(CompositorInputEvent::TouchDown {
+						slot: event.pointer_id,
+						x: event.x,
+						y: event.y,
+					}),
+					PointerEventKind::Move => Some(CompositorInputEvent::TouchMove {
+						slot: event.pointer_id,
+						x: event.x,
+						y: event.y,
+					}),
+					PointerEventKind::Up | PointerEventKind::Cancel => {
+						Some(CompositorInputEvent::TouchUp { slot: event.pointer_id })
+					},
+					PointerEventKind::CancelAll => Some(CompositorInputEvent::TouchCancelAll),
+					PointerEventKind::Hover | PointerEventKind::ButtonOnly | PointerEventKind::HoverLeave => None,
+				};
+				if let Some(event) = compositor_event {
+					let _ = self.input_tx.send(event);
+				}
+			},
+			InputEvent::Pen(event) => {
+				tracing::trace!("Pen input: {event:?}");
+				let _ = self.input_tx.send(CompositorInputEvent::Pen {
+					event_kind: event.event_kind as u8,
+					tool_kind: event.tool_kind as u8,
+					buttons: event.buttons,
+					x: event.x,
+					y: event.y,
+					pressure_or_distance: event.pressure_or_distance,
+					rotation: event.rotation,
+					tilt: event.tilt,
+				});
 			},
 			// Gamepad events: forward to gamepad handler thread.
 			gamepad_event => {

--- a/moonshine-core/src/session/stream/control/input/touch.rs
+++ b/moonshine-core/src/session/stream/control/input/touch.rs
@@ -1,0 +1,179 @@
+use strum_macros::FromRepr;
+
+const POINTER_PAYLOAD_SIZE: usize = 28;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub(crate) enum PointerEventKind {
+	Hover = 0x00,
+	Down = 0x01,
+	Up = 0x02,
+	Move = 0x03,
+	Cancel = 0x04,
+	ButtonOnly = 0x05,
+	HoverLeave = 0x06,
+	CancelAll = 0x07,
+}
+
+impl PointerEventKind {
+	fn has_position(self) -> bool {
+		matches!(self, Self::Hover | Self::Down | Self::Up | Self::Move)
+	}
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, FromRepr)]
+#[repr(u8)]
+pub(crate) enum PenToolKind {
+	Unknown = 0x00,
+	Pen = 0x01,
+	Eraser = 0x02,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Touch {
+	pub event_kind: PointerEventKind,
+	pub pointer_id: u32,
+	pub x: f32,
+	pub y: f32,
+}
+
+impl Touch {
+	pub fn from_bytes(buffer: &[u8]) -> Result<Self, ()> {
+		if buffer.len() < POINTER_PAYLOAD_SIZE {
+			tracing::warn!(
+				"Expected at least {POINTER_PAYLOAD_SIZE} bytes for Touch, got {} bytes.",
+				buffer.len()
+			);
+			return Err(());
+		}
+
+		let event_kind = PointerEventKind::from_repr(buffer[0])
+			.ok_or_else(|| tracing::warn!(event_type = buffer[0], "Unknown touch event type"))?;
+		let x = f32::from_le_bytes(buffer[8..12].try_into().unwrap());
+		let y = f32::from_le_bytes(buffer[12..16].try_into().unwrap());
+
+		if event_kind.has_position() && (!x.is_finite() || !y.is_finite()) {
+			tracing::warn!(?x, ?y, "Ignoring touch event with non-finite coordinates");
+			return Err(());
+		}
+
+		Ok(Self {
+			event_kind,
+			pointer_id: u32::from_le_bytes(buffer[4..8].try_into().unwrap()),
+			x,
+			y,
+		})
+	}
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Pen {
+	pub event_kind: PointerEventKind,
+	pub tool_kind: PenToolKind,
+	pub buttons: u8,
+	pub x: f32,
+	pub y: f32,
+	pub pressure_or_distance: f32,
+	pub rotation: u16,
+	pub tilt: u8,
+}
+
+impl Pen {
+	pub fn from_bytes(buffer: &[u8]) -> Result<Self, ()> {
+		if buffer.len() < POINTER_PAYLOAD_SIZE {
+			tracing::warn!(
+				"Expected at least {POINTER_PAYLOAD_SIZE} bytes for Pen, got {} bytes.",
+				buffer.len()
+			);
+			return Err(());
+		}
+
+		let event_kind = PointerEventKind::from_repr(buffer[0])
+			.ok_or_else(|| tracing::warn!(event_type = buffer[0], "Unknown pen event type"))?;
+		let tool_kind = PenToolKind::from_repr(buffer[1])
+			.ok_or_else(|| tracing::warn!(tool_type = buffer[1], "Unknown pen tool type"))?;
+		let x = f32::from_le_bytes(buffer[4..8].try_into().unwrap());
+		let y = f32::from_le_bytes(buffer[8..12].try_into().unwrap());
+		let pressure_or_distance = f32::from_le_bytes(buffer[12..16].try_into().unwrap());
+
+		if event_kind.has_position() && (!x.is_finite() || !y.is_finite() || !pressure_or_distance.is_finite()) {
+			tracing::warn!(
+				?x,
+				?y,
+				?pressure_or_distance,
+				"Ignoring pen event with non-finite values"
+			);
+			return Err(());
+		}
+
+		Ok(Self {
+			event_kind,
+			tool_kind,
+			buttons: buffer[2],
+			x,
+			y,
+			pressure_or_distance,
+			rotation: u16::from_le_bytes(buffer[16..18].try_into().unwrap()),
+			tilt: buffer[18],
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{Pen, PenToolKind, PointerEventKind, Touch};
+
+	#[test]
+	fn parses_touch_payload() {
+		let mut payload = [0_u8; 28];
+		payload[0] = PointerEventKind::Down as u8;
+		payload[4..8].copy_from_slice(&42_u32.to_le_bytes());
+		payload[8..12].copy_from_slice(&0.25_f32.to_le_bytes());
+		payload[12..16].copy_from_slice(&0.75_f32.to_le_bytes());
+
+		let touch = Touch::from_bytes(&payload).unwrap();
+		assert_eq!(touch.event_kind, PointerEventKind::Down);
+		assert_eq!(touch.pointer_id, 42);
+		assert_eq!(touch.x, 0.25);
+		assert_eq!(touch.y, 0.75);
+	}
+
+	#[test]
+	fn parses_pen_payload() {
+		let mut payload = [0_u8; 28];
+		payload[0] = PointerEventKind::Move as u8;
+		payload[1] = PenToolKind::Pen as u8;
+		payload[2] = 0x02;
+		payload[4..8].copy_from_slice(&0.25_f32.to_le_bytes());
+		payload[8..12].copy_from_slice(&0.75_f32.to_le_bytes());
+		payload[12..16].copy_from_slice(&0.6_f32.to_le_bytes());
+		payload[16..18].copy_from_slice(&270_u16.to_le_bytes());
+		payload[18] = 35;
+
+		let pen = Pen::from_bytes(&payload).unwrap();
+		assert_eq!(pen.event_kind, PointerEventKind::Move);
+		assert_eq!(pen.tool_kind, PenToolKind::Pen);
+		assert_eq!(pen.buttons, 0x02);
+		assert_eq!(pen.x, 0.25);
+		assert_eq!(pen.y, 0.75);
+		assert_eq!(pen.pressure_or_distance, 0.6);
+		assert_eq!(pen.rotation, 270);
+		assert_eq!(pen.tilt, 35);
+	}
+
+	#[test]
+	fn rejects_invalid_pointer_payloads() {
+		assert!(Touch::from_bytes(&[0; 27]).is_err());
+
+		let mut touch = [0_u8; 28];
+		touch[0] = PointerEventKind::Move as u8;
+		touch[8..12].copy_from_slice(&f32::NAN.to_le_bytes());
+		assert!(Touch::from_bytes(&touch).is_err());
+
+		let mut pen = [0_u8; 28];
+		pen[0] = PointerEventKind::Move as u8;
+		pen[1] = PenToolKind::Pen as u8;
+		pen[12..16].copy_from_slice(&f32::INFINITY.to_le_bytes());
+		assert!(Pen::from_bytes(&pen).is_err());
+	}
+}


### PR DESCRIPTION
## Summary

- advertise Moonlight's native pen/touch capability alongside controller touchpad support
- parse native multi-touch and pen packets from the control stream
- expose a Wayland touch device and tablet tool with pressure, hover distance, tilt, eraser, and stylus-button support
- ignore null/unmapped keyboard packets emitted by some touch clients and correctly decode 16-bit VK codes
- document touchscreen and pen/stylus support

## Implementation notes

- Touch contacts use their Moonlight pointer IDs as stable Wayland touch slots.
- Coordinates are clamped and mapped from normalized client coordinates into the active output.
- Pen cancel and hover-leave events release tip, buttons, and proximity state.
- Malformed, unknown, and non-finite pointer packets are rejected before reaching the compositor.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (113 tests passed)
- `cargo build --release --workspace`
- `git diff --check`
- connected a Moonlight touch client over LAN, launched Steam at 2778x1940/120 Hz with H.265, and verified native touch input without keyboard-warning spam

The installed AUR package was left unchanged; live validation used the release binary built from this branch.
