### PR TITLE
fix: reject resume requests for stale sessions

### DIFF
--- a/moonshine-core/src/session/manager.rs
+++ b/moonshine-core/src/session/manager.rs
@@ -452,15 +452,21 @@ impl SessionManager {
 	pub(crate) async fn update_keys(&self, keys: SessionKeyData) -> Result<(), ()> {
 		let guard = self.inner.lock().await;
 
-		if guard.session.is_none() {
-			tracing::warn!("No active session to update keys for.");
+		if guard.stop.is_shutdown_triggered() {
+			tracing::warn!("Session is shutting down; rejecting resume key update.");
+			return Err(());
+		}
+
+		if !matches!(guard.session.as_ref(), Some(SessionState::Active(_))) {
+			tracing::warn!("No active streaming session to update keys for.");
 			return Err(());
 		}
 
 		if let Some(keys_tx) = &guard.keys_tx {
 			keys_tx.send_replace(keys);
 		} else {
-			tracing::warn!("No active session to update keys for.");
+			tracing::warn!("Active streaming session has no key sender; rejecting resume.");
+			return Err(());
 		}
 
 		Ok(())


### PR DESCRIPTION
## Summary

Reject resume key updates when any of the following is true:

- Shutdown has started.
- The existing session is not `Active`.
- An `Active` session has no key sender.

This is a narrow follow-up to #103. That PR added support for reconnecting to an active stream, but `/resume` currently treats any existing session object as resumable. The shutdown signal can fire before the watchdog clears that object, leaving a short window where Moonshine acknowledges a resume for a stream that can no longer produce frames.

## Resume decision

Before this change, any existing session returned status 200. A missing key sender only logged a warning.

```mermaid
flowchart TD
    A["Receive /resume with new keys"] --> B{"Shutdown started?"}

    B -- Yes --> X["Return status code 400"]
    B -- No --> C{"Session is Active?"}

    C -- No --> X
    C -- Yes --> D{"Key sender exists?"}

    D -- No --> X
    D -- Yes --> E["Replace session keys"]
    E --> Y["Return status code 200"]
```

The original failure was observed during a Moonlight reconnect: Moonshine logged `ControlStreamStopped`, accepted `/resume` with status 200 during teardown, and then produced no video before Moonlight's first-frame timeout.
