### PR TITLE
fix(nix): disable nixpkgs module

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -136,6 +136,8 @@ in
     # is how the polkit rule below gets picked up.
     environment.systemPackages = [ cfg.package ];
 
+    disabledModules = [ "services/networking/moonshine.nix" ];
+
     # The moonshine-wsi Vulkan layer routes a game's swapchain frames into
     # moonshine's compositor. It is an *implicit* layer, so the loader has to
     # find its manifest by scanning, and a store path is only scanned when it


### PR DESCRIPTION
Rebuilding NixOS causes a failure because the latest `nixos-unstable` added their own separate moonshine module conflicting with the flake module. This PR fixes it by disabling the nixpkgs module.