### PR TITLE
fix(video): pace UDP shards to reduce burst loss

### DIFF
--- a/moonshine-core/src/session/stream/video/gso_socket.rs
+++ b/moonshine-core/src/session/stream/video/gso_socket.rs
@@ -1,6 +1,7 @@
 use quinn_udp::{Transmit, UdpSockRef, UdpSocketState};
 use tokio::net::UdpSocket;
 
+use super::pacer::Pacer;
 use super::shard_batch::ShardBatch;
 
 /// Maximum payload of one UDP datagram (65535 minus IPv4/UDP headers).
@@ -8,21 +9,6 @@ use super::shard_batch::ShardBatch;
 /// with EMSGSIZE before segmenting. IPv6 allows 20 more bytes; the IPv4
 /// value is safe for both.
 const MAX_UDP_PAYLOAD: usize = 65507;
-
-/// Approximate bytes added to each UDP payload on a VLAN Ethernet path:
-/// IPv4 + UDP + Ethernet/VLAN/FCS + preamble/SFD + inter-packet gap.
-const WIRE_OVERHEAD_BYTES: usize = 70;
-
-#[derive(Clone, Copy, Debug)]
-enum PacingMode {
-	Disabled,
-	Fixed(std::time::Duration),
-	Adaptive {
-		wire_rate_bps: u64,
-		frame_interval: std::time::Duration,
-		frame_budget_percent: u8,
-	},
-}
 
 #[derive(Debug, Default)]
 pub(crate) struct SendBatchResult {
@@ -36,30 +22,6 @@ pub(crate) struct SendBatchResult {
 	pub frame_deadline_missed: bool,
 }
 
-fn adaptive_pacing_interval(
-	shard_size: usize,
-	shard_count: usize,
-	wire_rate_bps: u64,
-	frame_interval: std::time::Duration,
-	frame_budget_percent: u8,
-) -> (std::time::Duration, bool) {
-	if shard_size == 0 || shard_count <= 1 || wire_rate_bps == 0 {
-		return (std::time::Duration::ZERO, false);
-	}
-
-	let wire_bits = (shard_size.saturating_add(WIRE_OVERHEAD_BYTES) as u128) * 8;
-	let rate_interval_ns = wire_bits.saturating_mul(1_000_000_000).div_ceil(wire_rate_bps as u128);
-	let gaps = (shard_count - 1) as u128;
-	let budget_ns = frame_interval
-		.as_nanos()
-		.saturating_mul(frame_budget_percent.clamp(1, 100) as u128)
-		/ 100;
-	let deadline_interval_ns = budget_ns / gaps;
-	let clamped = rate_interval_ns > deadline_interval_ns;
-	let interval_ns = rate_interval_ns.min(deadline_interval_ns).min(u64::MAX as u128) as u64;
-	(std::time::Duration::from_nanos(interval_ns), clamped)
-}
-
 /// Number of shards per GSO send: the kernel's segment-count cap or the
 /// datagram-size cap, whichever binds first. Never zero, even for a shard
 /// larger than a datagram (such a chunk fails at send time and falls back
@@ -71,34 +33,14 @@ fn gso_segments_per_send(max_gso_segments: usize, shard_size: usize) -> usize {
 }
 
 /// UDP socket for the video stream, with Generic Segmentation Offload.
-///
-/// Wraps a `tokio::net::UdpSocket` and quinn-udp's `UdpSocketState` so shard
-/// batches can be sent as GSO super-packets sized to the kernel's segment-count
-/// and datagram-size caps. Batches exceeding a cap are split into chunks; chunks
-/// the kernel rejects fall back to per-shard sends. Without GSO support, the
-/// socket sends everything per-shard.
 pub(crate) struct UdpGsoSocket {
 	socket: UdpSocket,
 	udp_state: UdpSocketState,
 	disable_gso: bool,
-	pacing: PacingMode,
+	pacer: Option<Pacer>,
 }
 
 impl UdpGsoSocket {
-	fn pacing_deadlines(&self) -> Option<(std::time::Duration, std::time::Duration)> {
-		match self.pacing {
-			PacingMode::Adaptive {
-				frame_interval,
-				frame_budget_percent,
-				..
-			} => Some((
-				frame_interval.mul_f64(f64::from(frame_budget_percent) / 100.0),
-				frame_interval,
-			)),
-			PacingMode::Disabled | PacingMode::Fixed(_) => None,
-		}
-	}
-
 	/// Bind a socket to `address:port` and initialize its GSO state.
 	pub async fn new(address: &str, port: u16) -> Result<Self, ()> {
 		let socket = UdpSocket::bind((address, port))
@@ -106,19 +48,8 @@ impl UdpGsoSocket {
 			.map_err(|e| tracing::error!("Failed to bind to UDP socket: {e}"))?;
 		let udp_state = UdpSocketState::new(UdpSockRef::from(&socket))
 			.map_err(|e| tracing::error!("Failed to initialize UDP socket state: {e}"))?;
-		let fixed_pacing = std::env::var("MOONSHINE_SHARD_PACING_US")
-			.ok()
-			.and_then(|value| value.parse::<u64>().ok())
-			.filter(|value| *value > 0)
-			.map(std::time::Duration::from_micros);
-		let disable_gso = std::env::var_os("MOONSHINE_DISABLE_GSO").is_some() || fixed_pacing.is_some();
-		let pacing = fixed_pacing.map_or(PacingMode::Disabled, PacingMode::Fixed);
-		if let Some(interval) = fixed_pacing {
-			tracing::info!(
-				pacing_us = interval.as_micros() as u64,
-				"GSO disabled; pacing video shards"
-			);
-		} else if disable_gso {
+		let disable_gso = std::env::var_os("MOONSHINE_DISABLE_GSO").is_some();
+		if disable_gso {
 			tracing::info!("GSO disabled by MOONSHINE_DISABLE_GSO");
 		} else if udp_state.max_gso_segments() > 1 {
 			tracing::debug!("GSO enabled, max segments: {}", udp_state.max_gso_segments());
@@ -129,29 +60,36 @@ impl UdpGsoSocket {
 			socket,
 			udp_state,
 			disable_gso,
-			pacing,
+			pacer: None,
 		})
 	}
 
-	/// Configure adaptive per-shard pacing for the negotiated stream. Environment
-	/// test controls take precedence so fixed-delay A/B runs remain reproducible.
-	pub fn configure_adaptive_pacing(&mut self, wire_rate_mbps: u32, fps: u32, frame_budget_percent: u8) {
-		if !matches!(self.pacing, PacingMode::Disabled) || wire_rate_mbps == 0 || fps == 0 {
+	/// Configure pacing from the bitrate and frame rate negotiated with the
+	/// client. A zero headroom percentage leaves pacing disabled.
+	pub fn configure_pacing(
+		&mut self,
+		client_bitrate_bps: usize,
+		fps: u32,
+		headroom_percent: u16,
+		frame_budget_percent: u8,
+	) {
+		if client_bitrate_bps == 0 || fps == 0 || headroom_percent == 0 {
+			tracing::info!("Video packet pacing disabled");
 			return;
 		}
 
-		self.disable_gso = true;
-		self.pacing = PacingMode::Adaptive {
-			wire_rate_bps: u64::from(wire_rate_mbps) * 1_000_000,
-			frame_interval: std::time::Duration::from_secs_f64(1.0 / f64::from(fps)),
-			frame_budget_percent: frame_budget_percent.clamp(1, 100),
-		};
-		tracing::info!(
-			wire_rate_mbps,
-			fps,
-			frame_budget_percent = frame_budget_percent.clamp(1, 100),
-			"GSO disabled; adaptive video shard pacing enabled"
-		);
+		match Pacer::new(client_bitrate_bps, fps, headroom_percent, frame_budget_percent) {
+			Ok(pacer) => {
+				self.pacer = Some(pacer);
+				tracing::info!(
+					client_bitrate_mbps = client_bitrate_bps / 1_000_000,
+					headroom_percent,
+					frame_budget_percent = frame_budget_percent.clamp(1, 100),
+					"Adaptive video packet pacing enabled"
+				);
+			},
+			Err(e) => tracing::warn!("Failed to initialize high-resolution video pacer: {e}"),
+		}
 	}
 
 	/// Local address the socket is bound to.
@@ -171,120 +109,112 @@ impl UdpGsoSocket {
 
 	/// Send a shard batch to `addr`.
 	///
-	/// Returns the number of chunks that fell back to per-shard sends because
-	/// the kernel rejected the GSO send (0 on success).
-	///
 	/// GSO availability is re-checked on every call: quinn-udp disables it at
 	/// runtime if the kernel or NIC rejects a segmented send.
-	pub async fn send_batch(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> SendBatchResult {
-		let started = tokio::time::Instant::now();
+	pub async fn send_batch(&mut self, batch: &ShardBatch, addr: std::net::SocketAddr) -> SendBatchResult {
+		let started = std::time::Instant::now();
+		let shard_size = batch.shard_size();
+		let shard_count = batch.shard_count();
 		let mut result = SendBatchResult {
-			shard_count: batch.shard_count(),
+			shard_count,
 			..SendBatchResult::default()
 		};
-		if !self.disable_gso && self.udp_state.max_gso_segments() > 1 {
-			let (failed_gso_chunks, send_errors) = self.send_batch_gso(batch, addr).await;
-			result.failed_gso_chunks = failed_gso_chunks;
-			result.send_errors = send_errors;
+		if shard_size == 0 || shard_count == 0 {
+			return result;
+		}
+
+		let max_gso_segments = if self.disable_gso {
+			1
 		} else {
-			let (send_errors, pacing_interval, deadline_clamped) =
-				self.send_shards(batch.as_bytes(), batch.shard_size(), addr).await;
-			result.send_errors = send_errors;
-			result.pacing_interval = pacing_interval;
-			result.deadline_clamped = deadline_clamped;
+			self.udp_state.max_gso_segments()
+		};
+		let max_segments_per_send = gso_segments_per_send(max_gso_segments, shard_size);
+		let pacing_deadlines = self
+			.pacer
+			.as_ref()
+			.map(|pacer| (pacer.frame_budget(), pacer.frame_interval()));
+		let mut schedule = self
+			.pacer
+			.as_ref()
+			.map(|pacer| pacer.schedule_batch(shard_size, shard_count, max_segments_per_send));
+		let segments_per_send = schedule
+			.as_ref()
+			.map_or(max_segments_per_send, |schedule| schedule.segments_per_send);
+		if let Some(schedule) = &schedule {
+			result.pacing_interval = Some(schedule.pacing_interval);
+			result.deadline_clamped = schedule.deadline_clamped;
+		}
+
+		let mut pacing_failed = false;
+		for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
+			if !pacing_failed && let (Some(pacer), Some(schedule)) = (&mut self.pacer, &mut schedule) {
+				if let Err(e) = pacer.wait(schedule).await {
+					tracing::warn!("High-resolution video pacer failed; disabling pacing: {e}");
+					pacing_failed = true;
+				}
+				schedule.advance(chunk.len().div_ceil(shard_size));
+			}
+
+			let (failed_gso, send_errors) =
+				send_gso_chunk(&self.socket, &self.udp_state, chunk, shard_size, addr).await;
+			result.failed_gso_chunks += u32::from(failed_gso);
+			result.send_errors += send_errors;
+		}
+
+		if pacing_failed {
+			self.pacer = None;
 		}
 		result.elapsed = started.elapsed();
-		if let Some((pacing_budget, frame_deadline)) = self.pacing_deadlines() {
+		if let Some((pacing_budget, frame_deadline)) = pacing_deadlines {
 			result.pacing_budget_missed = result.elapsed > pacing_budget;
 			result.frame_deadline_missed = result.elapsed > frame_deadline;
 		}
 		result
 	}
+}
 
-	/// Send a batch as GSO chunks sized to the kernel's segment and datagram
-	/// caps; a frame's batch routinely exceeds both. Uses `try_send` because
-	/// `send` masks every error except `WouldBlock` as success, silently
-	/// discarding the batch.
-	async fn send_batch_gso(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> (u32, u32) {
-		let shard_size = batch.shard_size();
-		if shard_size == 0 {
-			return (0, 0);
-		}
-		let segments_per_send = gso_segments_per_send(self.udp_state.max_gso_segments(), shard_size);
-
-		let mut failed_chunks = 0u32;
-		let mut send_errors = 0u32;
-		for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
-			let transmit = Transmit {
-				destination: addr,
-				ecn: None,
-				contents: chunk,
-				segment_size: Some(shard_size),
-				src_ip: None,
-			};
-			let result = loop {
-				match self.udp_state.try_send(UdpSockRef::from(&self.socket), &transmit) {
-					// A frame burst can outrun the socket buffer; wait for it to
-					// drain and resend the same chunk instead of degrading.
-					Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-						self.socket.writable().await.ok();
-					},
-					other => break other,
-				}
-			};
-			if let Err(e) = result {
-				failed_chunks += 1;
-				tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
-				let (errors, _, _) = self.send_shards(chunk, shard_size, addr).await;
-				send_errors += errors;
-			}
-		}
-		(failed_chunks, send_errors)
-	}
-
-	/// Send a contiguous buffer of equal-sized shards as individual UDP packets.
-	async fn send_shards(
-		&self,
-		bytes: &[u8],
-		shard_size: usize,
-		addr: std::net::SocketAddr,
-	) -> (u32, Option<std::time::Duration>, bool) {
-		if shard_size == 0 {
-			return (0, None, false);
-		}
-		let shard_count = bytes.len().div_ceil(shard_size);
-		let (pacing_interval, deadline_clamped) = match self.pacing {
-			PacingMode::Disabled => (None, false),
-			PacingMode::Fixed(interval) => (Some(interval), false),
-			PacingMode::Adaptive {
-				wire_rate_bps,
-				frame_interval,
-				frame_budget_percent,
-			} => {
-				let (interval, clamped) = adaptive_pacing_interval(
-					shard_size,
-					shard_count,
-					wire_rate_bps,
-					frame_interval,
-					frame_budget_percent,
-				);
-				(Some(interval), clamped)
+/// Send one GSO chunk. If the kernel rejects segmentation, retry each shard so
+/// the frame is not silently discarded.
+async fn send_gso_chunk(
+	socket: &UdpSocket,
+	udp_state: &UdpSocketState,
+	chunk: &[u8],
+	shard_size: usize,
+	addr: std::net::SocketAddr,
+) -> (bool, u32) {
+	let transmit = Transmit {
+		destination: addr,
+		ecn: None,
+		contents: chunk,
+		segment_size: Some(shard_size),
+		src_ip: None,
+	};
+	let send_result = loop {
+		match udp_state.try_send(UdpSockRef::from(socket), &transmit) {
+			Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+				socket.writable().await.ok();
 			},
-		};
-		let mut next_send = tokio::time::Instant::now();
-		let mut send_errors = 0u32;
-		for (index, shard) in bytes.chunks(shard_size).enumerate() {
-			if let Err(e) = self.socket.send_to(shard, addr).await {
-				tracing::warn!("Failed to send packet to client: {e}");
-				send_errors += 1;
-			}
-			if let Some(interval) = pacing_interval.filter(|_| index + 1 < shard_count) {
-				next_send += interval;
-				tokio::time::sleep_until(next_send).await;
-			}
+			other => break other,
 		}
-		(send_errors, pacing_interval, deadline_clamped)
+	};
+	match send_result {
+		Ok(()) => (false, 0),
+		Err(e) => {
+			tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
+			(true, send_shards(socket, chunk, shard_size, addr).await)
+		},
 	}
+}
+
+async fn send_shards(socket: &UdpSocket, bytes: &[u8], shard_size: usize, addr: std::net::SocketAddr) -> u32 {
+	let mut send_errors = 0u32;
+	for shard in bytes.chunks(shard_size) {
+		if let Err(e) = socket.send_to(shard, addr).await {
+			tracing::warn!("Failed to send packet to client: {e}");
+			send_errors += 1;
+		}
+	}
+	send_errors
 }
 
 #[cfg(test)]
@@ -324,39 +254,5 @@ mod tests {
 				assert!(chunk.len() / shard_size <= 64, "chunk must respect segment cap");
 			}
 		}
-	}
-
-	#[test]
-	fn adaptive_pacing_targets_configured_wire_rate() {
-		let (interval, clamped) = adaptive_pacing_interval(
-			1392,
-			100,
-			120_000_000,
-			std::time::Duration::from_secs_f64(1.0 / 60.0),
-			80,
-		);
-		assert_eq!(interval, std::time::Duration::from_nanos(97_467));
-		assert!(!clamped);
-	}
-
-	#[test]
-	fn adaptive_pacing_honors_frame_deadline() {
-		let frame_interval = std::time::Duration::from_millis(10);
-		let (interval, clamped) = adaptive_pacing_interval(1392, 101, 1_000_000, frame_interval, 80);
-		assert_eq!(interval, std::time::Duration::from_micros(80));
-		assert!(clamped);
-	}
-
-	#[test]
-	fn adaptive_pacing_handles_degenerate_batches() {
-		let frame_interval = std::time::Duration::from_millis(16);
-		assert_eq!(
-			adaptive_pacing_interval(1392, 1, 120_000_000, frame_interval, 80),
-			(std::time::Duration::ZERO, false)
-		);
-		assert_eq!(
-			adaptive_pacing_interval(1392, 10, 0, frame_interval, 80),
-			(std::time::Duration::ZERO, false)
-		);
 	}
 }

--- a/moonshine-core/src/session/stream/video/gso_socket.rs
+++ b/moonshine-core/src/session/stream/video/gso_socket.rs
@@ -9,6 +9,57 @@ use super::shard_batch::ShardBatch;
 /// value is safe for both.
 const MAX_UDP_PAYLOAD: usize = 65507;
 
+/// Approximate bytes added to each UDP payload on a VLAN Ethernet path:
+/// IPv4 + UDP + Ethernet/VLAN/FCS + preamble/SFD + inter-packet gap.
+const WIRE_OVERHEAD_BYTES: usize = 70;
+
+#[derive(Clone, Copy, Debug)]
+enum PacingMode {
+	Disabled,
+	Fixed(std::time::Duration),
+	Adaptive {
+		wire_rate_bps: u64,
+		frame_interval: std::time::Duration,
+		frame_budget_percent: u8,
+	},
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SendBatchResult {
+	pub failed_gso_chunks: u32,
+	pub send_errors: u32,
+	pub shard_count: usize,
+	pub elapsed: std::time::Duration,
+	pub pacing_interval: Option<std::time::Duration>,
+	pub deadline_clamped: bool,
+	pub pacing_budget_missed: bool,
+	pub frame_deadline_missed: bool,
+}
+
+fn adaptive_pacing_interval(
+	shard_size: usize,
+	shard_count: usize,
+	wire_rate_bps: u64,
+	frame_interval: std::time::Duration,
+	frame_budget_percent: u8,
+) -> (std::time::Duration, bool) {
+	if shard_size == 0 || shard_count <= 1 || wire_rate_bps == 0 {
+		return (std::time::Duration::ZERO, false);
+	}
+
+	let wire_bits = (shard_size.saturating_add(WIRE_OVERHEAD_BYTES) as u128) * 8;
+	let rate_interval_ns = wire_bits.saturating_mul(1_000_000_000).div_ceil(wire_rate_bps as u128);
+	let gaps = (shard_count - 1) as u128;
+	let budget_ns = frame_interval
+		.as_nanos()
+		.saturating_mul(frame_budget_percent.clamp(1, 100) as u128)
+		/ 100;
+	let deadline_interval_ns = budget_ns / gaps;
+	let clamped = rate_interval_ns > deadline_interval_ns;
+	let interval_ns = rate_interval_ns.min(deadline_interval_ns).min(u64::MAX as u128) as u64;
+	(std::time::Duration::from_nanos(interval_ns), clamped)
+}
+
 /// Number of shards per GSO send: the kernel's segment-count cap or the
 /// datagram-size cap, whichever binds first. Never zero, even for a shard
 /// larger than a datagram (such a chunk fails at send time and falls back
@@ -29,9 +80,25 @@ fn gso_segments_per_send(max_gso_segments: usize, shard_size: usize) -> usize {
 pub(crate) struct UdpGsoSocket {
 	socket: UdpSocket,
 	udp_state: UdpSocketState,
+	disable_gso: bool,
+	pacing: PacingMode,
 }
 
 impl UdpGsoSocket {
+	fn pacing_deadlines(&self) -> Option<(std::time::Duration, std::time::Duration)> {
+		match self.pacing {
+			PacingMode::Adaptive {
+				frame_interval,
+				frame_budget_percent,
+				..
+			} => Some((
+				frame_interval.mul_f64(f64::from(frame_budget_percent) / 100.0),
+				frame_interval,
+			)),
+			PacingMode::Disabled | PacingMode::Fixed(_) => None,
+		}
+	}
+
 	/// Bind a socket to `address:port` and initialize its GSO state.
 	pub async fn new(address: &str, port: u16) -> Result<Self, ()> {
 		let socket = UdpSocket::bind((address, port))
@@ -39,12 +106,52 @@ impl UdpGsoSocket {
 			.map_err(|e| tracing::error!("Failed to bind to UDP socket: {e}"))?;
 		let udp_state = UdpSocketState::new(UdpSockRef::from(&socket))
 			.map_err(|e| tracing::error!("Failed to initialize UDP socket state: {e}"))?;
-		if udp_state.max_gso_segments() > 1 {
+		let fixed_pacing = std::env::var("MOONSHINE_SHARD_PACING_US")
+			.ok()
+			.and_then(|value| value.parse::<u64>().ok())
+			.filter(|value| *value > 0)
+			.map(std::time::Duration::from_micros);
+		let disable_gso = std::env::var_os("MOONSHINE_DISABLE_GSO").is_some() || fixed_pacing.is_some();
+		let pacing = fixed_pacing.map_or(PacingMode::Disabled, PacingMode::Fixed);
+		if let Some(interval) = fixed_pacing {
+			tracing::info!(
+				pacing_us = interval.as_micros() as u64,
+				"GSO disabled; pacing video shards"
+			);
+		} else if disable_gso {
+			tracing::info!("GSO disabled by MOONSHINE_DISABLE_GSO");
+		} else if udp_state.max_gso_segments() > 1 {
 			tracing::debug!("GSO enabled, max segments: {}", udp_state.max_gso_segments());
 		} else {
 			tracing::debug!("GSO not available, using per-shard sends");
 		}
-		Ok(Self { socket, udp_state })
+		Ok(Self {
+			socket,
+			udp_state,
+			disable_gso,
+			pacing,
+		})
+	}
+
+	/// Configure adaptive per-shard pacing for the negotiated stream. Environment
+	/// test controls take precedence so fixed-delay A/B runs remain reproducible.
+	pub fn configure_adaptive_pacing(&mut self, wire_rate_mbps: u32, fps: u32, frame_budget_percent: u8) {
+		if !matches!(self.pacing, PacingMode::Disabled) || wire_rate_mbps == 0 || fps == 0 {
+			return;
+		}
+
+		self.disable_gso = true;
+		self.pacing = PacingMode::Adaptive {
+			wire_rate_bps: u64::from(wire_rate_mbps) * 1_000_000,
+			frame_interval: std::time::Duration::from_secs_f64(1.0 / f64::from(fps)),
+			frame_budget_percent: frame_budget_percent.clamp(1, 100),
+		};
+		tracing::info!(
+			wire_rate_mbps,
+			fps,
+			frame_budget_percent = frame_budget_percent.clamp(1, 100),
+			"GSO disabled; adaptive video shard pacing enabled"
+		);
 	}
 
 	/// Local address the socket is bound to.
@@ -69,27 +176,44 @@ impl UdpGsoSocket {
 	///
 	/// GSO availability is re-checked on every call: quinn-udp disables it at
 	/// runtime if the kernel or NIC rejects a segmented send.
-	pub async fn send_batch(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> u32 {
-		if self.udp_state.max_gso_segments() > 1 {
-			self.send_batch_gso(batch, addr).await
+	pub async fn send_batch(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> SendBatchResult {
+		let started = tokio::time::Instant::now();
+		let mut result = SendBatchResult {
+			shard_count: batch.shard_count(),
+			..SendBatchResult::default()
+		};
+		if !self.disable_gso && self.udp_state.max_gso_segments() > 1 {
+			let (failed_gso_chunks, send_errors) = self.send_batch_gso(batch, addr).await;
+			result.failed_gso_chunks = failed_gso_chunks;
+			result.send_errors = send_errors;
 		} else {
-			self.send_shards(batch.as_bytes(), batch.shard_size(), addr).await;
-			0
+			let (send_errors, pacing_interval, deadline_clamped) =
+				self.send_shards(batch.as_bytes(), batch.shard_size(), addr).await;
+			result.send_errors = send_errors;
+			result.pacing_interval = pacing_interval;
+			result.deadline_clamped = deadline_clamped;
 		}
+		result.elapsed = started.elapsed();
+		if let Some((pacing_budget, frame_deadline)) = self.pacing_deadlines() {
+			result.pacing_budget_missed = result.elapsed > pacing_budget;
+			result.frame_deadline_missed = result.elapsed > frame_deadline;
+		}
+		result
 	}
 
 	/// Send a batch as GSO chunks sized to the kernel's segment and datagram
 	/// caps; a frame's batch routinely exceeds both. Uses `try_send` because
 	/// `send` masks every error except `WouldBlock` as success, silently
 	/// discarding the batch.
-	async fn send_batch_gso(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> u32 {
+	async fn send_batch_gso(&self, batch: &ShardBatch, addr: std::net::SocketAddr) -> (u32, u32) {
 		let shard_size = batch.shard_size();
 		if shard_size == 0 {
-			return 0;
+			return (0, 0);
 		}
 		let segments_per_send = gso_segments_per_send(self.udp_state.max_gso_segments(), shard_size);
 
 		let mut failed_chunks = 0u32;
+		let mut send_errors = 0u32;
 		for chunk in batch.as_bytes().chunks(segments_per_send * shard_size) {
 			let transmit = Transmit {
 				destination: addr,
@@ -111,22 +235,55 @@ impl UdpGsoSocket {
 			if let Err(e) = result {
 				failed_chunks += 1;
 				tracing::debug!("GSO send failed ({e}), falling back to per-shard sends for this chunk");
-				self.send_shards(chunk, shard_size, addr).await;
+				let (errors, _, _) = self.send_shards(chunk, shard_size, addr).await;
+				send_errors += errors;
 			}
 		}
-		failed_chunks
+		(failed_chunks, send_errors)
 	}
 
 	/// Send a contiguous buffer of equal-sized shards as individual UDP packets.
-	async fn send_shards(&self, bytes: &[u8], shard_size: usize, addr: std::net::SocketAddr) {
+	async fn send_shards(
+		&self,
+		bytes: &[u8],
+		shard_size: usize,
+		addr: std::net::SocketAddr,
+	) -> (u32, Option<std::time::Duration>, bool) {
 		if shard_size == 0 {
-			return;
+			return (0, None, false);
 		}
-		for shard in bytes.chunks(shard_size) {
+		let shard_count = bytes.len().div_ceil(shard_size);
+		let (pacing_interval, deadline_clamped) = match self.pacing {
+			PacingMode::Disabled => (None, false),
+			PacingMode::Fixed(interval) => (Some(interval), false),
+			PacingMode::Adaptive {
+				wire_rate_bps,
+				frame_interval,
+				frame_budget_percent,
+			} => {
+				let (interval, clamped) = adaptive_pacing_interval(
+					shard_size,
+					shard_count,
+					wire_rate_bps,
+					frame_interval,
+					frame_budget_percent,
+				);
+				(Some(interval), clamped)
+			},
+		};
+		let mut next_send = tokio::time::Instant::now();
+		let mut send_errors = 0u32;
+		for (index, shard) in bytes.chunks(shard_size).enumerate() {
 			if let Err(e) = self.socket.send_to(shard, addr).await {
 				tracing::warn!("Failed to send packet to client: {e}");
+				send_errors += 1;
+			}
+			if let Some(interval) = pacing_interval.filter(|_| index + 1 < shard_count) {
+				next_send += interval;
+				tokio::time::sleep_until(next_send).await;
 			}
 		}
+		(send_errors, pacing_interval, deadline_clamped)
 	}
 }
 
@@ -167,5 +324,39 @@ mod tests {
 				assert!(chunk.len() / shard_size <= 64, "chunk must respect segment cap");
 			}
 		}
+	}
+
+	#[test]
+	fn adaptive_pacing_targets_configured_wire_rate() {
+		let (interval, clamped) = adaptive_pacing_interval(
+			1392,
+			100,
+			120_000_000,
+			std::time::Duration::from_secs_f64(1.0 / 60.0),
+			80,
+		);
+		assert_eq!(interval, std::time::Duration::from_nanos(97_467));
+		assert!(!clamped);
+	}
+
+	#[test]
+	fn adaptive_pacing_honors_frame_deadline() {
+		let frame_interval = std::time::Duration::from_millis(10);
+		let (interval, clamped) = adaptive_pacing_interval(1392, 101, 1_000_000, frame_interval, 80);
+		assert_eq!(interval, std::time::Duration::from_micros(80));
+		assert!(clamped);
+	}
+
+	#[test]
+	fn adaptive_pacing_handles_degenerate_batches() {
+		let frame_interval = std::time::Duration::from_millis(16);
+		assert_eq!(
+			adaptive_pacing_interval(1392, 1, 120_000_000, frame_interval, 80),
+			(std::time::Duration::ZERO, false)
+		);
+		assert_eq!(
+			adaptive_pacing_interval(1392, 10, 0, frame_interval, 80),
+			(std::time::Duration::ZERO, false)
+		);
 	}
 }

--- a/moonshine-core/src/session/stream/video/mod.rs
+++ b/moonshine-core/src/session/stream/video/mod.rs
@@ -9,6 +9,7 @@ use crate::session::compositor::frame::{ExportedFrame, HdrModeState};
 use crate::session::manager::SessionShutdownReason;
 
 mod gso_socket;
+mod pacer;
 mod packetizer;
 mod pipeline;
 mod shard_batch;
@@ -35,10 +36,11 @@ pub struct VideoStreamConfig {
 	#[serde(default)]
 	pub log_frame_spikes: bool,
 
-	/// Target on-wire rate used to pace video UDP shards. Zero disables pacing
-	/// and retains UDP GSO. This is a burst-rate ceiling, not the codec bitrate.
-	#[serde(default)]
-	pub pacing_wire_rate_mbps: u32,
+	/// Percentage of the client-requested bitrate available to the video packet
+	/// pacer. Zero disables pacing. Values above 100 provide headroom for FEC,
+	/// frame-size variation, and protocol overhead.
+	#[serde(default = "default_pacing_bitrate_headroom_percent")]
+	pub pacing_bitrate_headroom_percent: u16,
 
 	/// Maximum fraction of one frame interval that a paced batch may consume.
 	/// Larger batches are accelerated to meet this deadline rather than building
@@ -51,6 +53,10 @@ const fn default_pacing_frame_budget_percent() -> u8 {
 	80
 }
 
+const fn default_pacing_bitrate_headroom_percent() -> u16 {
+	200
+}
+
 impl Default for VideoStreamConfig {
 	fn default() -> Self {
 		Self {
@@ -58,7 +64,7 @@ impl Default for VideoStreamConfig {
 			fec_percentage: 20,
 			encrypt: false,
 			log_frame_spikes: false,
-			pacing_wire_rate_mbps: 0,
+			pacing_bitrate_headroom_percent: default_pacing_bitrate_headroom_percent(),
 			pacing_frame_budget_percent: default_pacing_frame_budget_percent(),
 		}
 	}
@@ -302,9 +308,10 @@ impl VideoStream {
 			stats_tx,
 		} = self;
 
-		socket.configure_adaptive_pacing(
-			config.pacing_wire_rate_mbps,
+		socket.configure_pacing(
+			context.bitrate,
 			context.fps,
+			config.pacing_bitrate_headroom_percent,
 			config.pacing_frame_budget_percent,
 		);
 
@@ -361,7 +368,7 @@ impl VideoStream {
 
 fn spawn_handle_video_packets(
 	mut packet_rx: mpsc::Receiver<ShardBatch>,
-	socket: UdpGsoSocket,
+	mut socket: UdpGsoSocket,
 	start: Arc<Notify>,
 	stop_session_manager: ShutdownManager<SessionShutdownReason>,
 ) {

--- a/moonshine-core/src/session/stream/video/mod.rs
+++ b/moonshine-core/src/session/stream/video/mod.rs
@@ -34,6 +34,21 @@ pub struct VideoStreamConfig {
 	/// packetize than the frame budget.
 	#[serde(default)]
 	pub log_frame_spikes: bool,
+
+	/// Target on-wire rate used to pace video UDP shards. Zero disables pacing
+	/// and retains UDP GSO. This is a burst-rate ceiling, not the codec bitrate.
+	#[serde(default)]
+	pub pacing_wire_rate_mbps: u32,
+
+	/// Maximum fraction of one frame interval that a paced batch may consume.
+	/// Larger batches are accelerated to meet this deadline rather than building
+	/// latency in the sender queue.
+	#[serde(default = "default_pacing_frame_budget_percent")]
+	pub pacing_frame_budget_percent: u8,
+}
+
+const fn default_pacing_frame_budget_percent() -> u8 {
+	80
 }
 
 impl Default for VideoStreamConfig {
@@ -43,6 +58,8 @@ impl Default for VideoStreamConfig {
 			fec_percentage: 20,
 			encrypt: false,
 			log_frame_spikes: false,
+			pacing_wire_rate_mbps: 0,
+			pacing_frame_budget_percent: default_pacing_frame_budget_percent(),
 		}
 	}
 }
@@ -279,11 +296,17 @@ impl VideoStream {
 		stop: ShutdownManager<SessionShutdownReason>,
 	) -> Result<VideoStreamHandle, ()> {
 		let Self {
-			socket,
+			mut socket,
 			frame_rx,
 			hdr_metadata_tx,
 			stats_tx,
 		} = self;
+
+		socket.configure_adaptive_pacing(
+			config.pacing_wire_rate_mbps,
+			context.fps,
+			config.pacing_frame_budget_percent,
+		);
 
 		// Apply QoS to UDP socket.
 		if context.qos {
@@ -349,6 +372,17 @@ fn spawn_handle_video_packets(
 		let mut client_address = None;
 		// Rate-limits the GSO-fallback warning.
 		let mut last_send_warn: Option<std::time::Instant> = None;
+		let mut sender_stats_started = std::time::Instant::now();
+		let mut sent_batches = 0u64;
+		let mut sent_shards = 0u64;
+		let mut deadline_clamped_batches = 0u64;
+		let mut pacing_budget_missed_batches = 0u64;
+		let mut frame_deadline_missed_batches = 0u64;
+		let mut failed_gso_chunks = 0u64;
+		let mut send_errors = 0u64;
+		let mut max_queue_age = std::time::Duration::ZERO;
+		let mut max_send_elapsed = std::time::Duration::ZERO;
+		let mut max_pacing_interval = std::time::Duration::ZERO;
 
 		// Trigger session shutdown if we exit unexpectedly.
 		let _stop_token = stop_session_manager.trigger_shutdown_token(SessionShutdownReason::VideoPacketHandlerStopped);
@@ -363,6 +397,7 @@ fn spawn_handle_video_packets(
 								if batch.shard_count() == 0 {
 									continue;
 								}
+								let queue_age = batch.queue_age();
 
 								// Sends are wrapped in wrap_cancel so a socket that
 								// stops draining cannot block session shutdown.
@@ -370,15 +405,54 @@ fn spawn_handle_video_packets(
 									.wrap_cancel(socket.send_batch(&batch, addr))
 									.await
 								{
-									Ok(failed_chunks) => {
-										if failed_chunks > 0
+									Ok(result) => {
+										sent_batches += 1;
+										sent_shards += result.shard_count as u64;
+										deadline_clamped_batches += u64::from(result.deadline_clamped);
+										pacing_budget_missed_batches += u64::from(result.pacing_budget_missed);
+										frame_deadline_missed_batches += u64::from(result.frame_deadline_missed);
+										failed_gso_chunks += u64::from(result.failed_gso_chunks);
+										send_errors += u64::from(result.send_errors);
+										max_queue_age = max_queue_age.max(queue_age);
+										max_send_elapsed = max_send_elapsed.max(result.elapsed);
+										max_pacing_interval = max_pacing_interval.max(result.pacing_interval.unwrap_or_default());
+
+										if result.failed_gso_chunks > 0
 											&& last_send_warn
 												.is_none_or(|t| t.elapsed() >= std::time::Duration::from_secs(1))
 										{
 											tracing::warn!(
-												"GSO send failed for {failed_chunks} chunk(s), sent per-shard instead"
+												"GSO send failed for {} chunk(s), sent per-shard instead",
+												result.failed_gso_chunks
 											);
 											last_send_warn = Some(std::time::Instant::now());
+										}
+
+										if sender_stats_started.elapsed() >= std::time::Duration::from_secs(5) {
+											tracing::info!(
+												batches = sent_batches,
+												shards = sent_shards,
+												deadline_clamped_batches,
+												pacing_budget_missed_batches,
+												frame_deadline_missed_batches,
+												failed_gso_chunks,
+												send_errors,
+												max_queue_age_us = max_queue_age.as_micros() as u64,
+												max_send_us = max_send_elapsed.as_micros() as u64,
+												max_pacing_interval_us = max_pacing_interval.as_micros() as u64,
+												"Video sender stats"
+											);
+											sender_stats_started = std::time::Instant::now();
+											sent_batches = 0;
+											sent_shards = 0;
+											deadline_clamped_batches = 0;
+											pacing_budget_missed_batches = 0;
+											frame_deadline_missed_batches = 0;
+											failed_gso_chunks = 0;
+											send_errors = 0;
+											max_queue_age = std::time::Duration::ZERO;
+											max_send_elapsed = std::time::Duration::ZERO;
+											max_pacing_interval = std::time::Duration::ZERO;
 										}
 									},
 									Err(_) => break,

--- a/moonshine-core/src/session/stream/video/pacer.rs
+++ b/moonshine-core/src/session/stream/video/pacer.rs
@@ -1,0 +1,172 @@
+use std::time::{Duration, Instant};
+
+use mio_timerfd::{ClockId, TimerFd};
+use tokio::io::unix::AsyncFd;
+
+/// Approximate bytes added to each UDP payload on a VLAN Ethernet path:
+/// IPv4 + UDP + Ethernet/VLAN/FCS + preamble/SFD + inter-packet gap.
+const WIRE_OVERHEAD_BYTES: usize = 70;
+
+/// Keep each GSO burst close to half a millisecond of on-wire data. The kernel
+/// still segments several shards per send, while the pacer prevents a complete
+/// encoded frame from entering the network queue at once.
+const TARGET_BURST_DURATION: Duration = Duration::from_micros(500);
+
+pub(super) struct Pacer {
+	timer: AsyncFd<TimerFd>,
+	target_wire_rate_bps: u64,
+	frame_interval: Duration,
+	frame_budget_percent: u8,
+}
+
+pub(super) struct BatchSchedule {
+	pub segments_per_send: usize,
+	pub deadline_clamped: bool,
+	pub pacing_interval: Duration,
+	next_send: Instant,
+	wire_rate_bps: u64,
+	wire_bytes_per_segment: usize,
+}
+
+impl Pacer {
+	pub fn new(
+		client_bitrate_bps: usize,
+		fps: u32,
+		headroom_percent: u16,
+		frame_budget_percent: u8,
+	) -> std::io::Result<Self> {
+		let timer = TimerFd::new(ClockId::Monotonic)?;
+		let timer = AsyncFd::new(timer)?;
+		let target_wire_rate_bps = wire_rate_with_headroom(client_bitrate_bps, headroom_percent);
+		Ok(Self {
+			timer,
+			target_wire_rate_bps,
+			frame_interval: Duration::from_secs_f64(1.0 / f64::from(fps)),
+			frame_budget_percent: frame_budget_percent.clamp(1, 100),
+		})
+	}
+
+	pub fn frame_budget(&self) -> Duration {
+		self.frame_interval
+			.mul_f64(f64::from(self.frame_budget_percent) / 100.0)
+	}
+
+	pub fn frame_interval(&self) -> Duration {
+		self.frame_interval
+	}
+
+	pub fn schedule_batch(&self, shard_size: usize, shard_count: usize, max_segments_per_send: usize) -> BatchSchedule {
+		batch_schedule(
+			shard_size,
+			shard_count,
+			max_segments_per_send,
+			self.target_wire_rate_bps,
+			self.frame_budget(),
+		)
+	}
+
+	pub async fn wait(&mut self, schedule: &BatchSchedule) -> std::io::Result<()> {
+		loop {
+			let Some(delay) = schedule.next_send.checked_duration_since(Instant::now()) else {
+				return Ok(());
+			};
+			self.timer.get_mut().set_timeout(&delay)?;
+			let mut ready = self.timer.readable_mut().await?;
+			match ready.get_inner().read()? {
+				0 => ready.clear_ready(),
+				_ => {
+					// Reading a one-shot timerfd consumes the expiration, so the
+					// descriptor is no longer readable until it is rearmed.
+					ready.clear_ready();
+					return Ok(());
+				},
+			}
+		}
+	}
+}
+
+fn wire_rate_with_headroom(client_bitrate_bps: usize, headroom_percent: u16) -> u64 {
+	(client_bitrate_bps as u128)
+		.saturating_mul(u128::from(headroom_percent))
+		.div_ceil(100)
+		.min(u128::from(u64::MAX)) as u64
+}
+
+impl BatchSchedule {
+	pub fn advance(&mut self, segment_count: usize) {
+		let wire_bits = (self.wire_bytes_per_segment.saturating_mul(segment_count) as u128) * 8;
+		let interval_ns = wire_bits
+			.saturating_mul(1_000_000_000)
+			.div_ceil(u128::from(self.wire_rate_bps))
+			.min(u128::from(u64::MAX)) as u64;
+		self.next_send += Duration::from_nanos(interval_ns);
+	}
+}
+
+fn batch_schedule(
+	shard_size: usize,
+	shard_count: usize,
+	max_segments_per_send: usize,
+	target_wire_rate_bps: u64,
+	frame_budget: Duration,
+) -> BatchSchedule {
+	let wire_bytes_per_segment = shard_size.saturating_add(WIRE_OVERHEAD_BYTES);
+	let total_wire_bits = (wire_bytes_per_segment.saturating_mul(shard_count) as u128) * 8;
+	let required_wire_rate_bps = total_wire_bits
+		.saturating_mul(1_000_000_000)
+		.div_ceil(frame_budget.as_nanos().max(1))
+		.min(u128::from(u64::MAX)) as u64;
+	let wire_rate_bps = target_wire_rate_bps.max(required_wire_rate_bps).max(1);
+	let deadline_clamped = required_wire_rate_bps > target_wire_rate_bps;
+
+	let burst_wire_bytes = (u128::from(wire_rate_bps)).saturating_mul(TARGET_BURST_DURATION.as_nanos()) / 8_000_000_000;
+	let segments_per_send = (burst_wire_bytes / wire_bytes_per_segment.max(1) as u128)
+		.max(1)
+		.min(max_segments_per_send.max(1) as u128) as usize;
+	let pacing_interval_ns = (wire_bytes_per_segment.saturating_mul(segments_per_send) as u128)
+		.saturating_mul(8_000_000_000)
+		.div_ceil(u128::from(wire_rate_bps))
+		.min(u128::from(u64::MAX)) as u64;
+
+	BatchSchedule {
+		segments_per_send,
+		deadline_clamped,
+		pacing_interval: Duration::from_nanos(pacing_interval_ns),
+		next_send: Instant::now(),
+		wire_rate_bps,
+		wire_bytes_per_segment,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn derives_rate_from_client_bitrate_with_headroom() {
+		assert_eq!(wire_rate_with_headroom(60_000_000, 200), 120_000_000);
+		assert_eq!(wire_rate_with_headroom(60_000_000, 0), 0);
+	}
+
+	#[test]
+	fn schedules_small_gso_bursts_at_derived_rate() {
+		let schedule = batch_schedule(1392, 100, 46, 120_000_000, Duration::from_millis(13));
+		assert_eq!(schedule.segments_per_send, 5);
+		assert!(!schedule.deadline_clamped);
+		assert_eq!(schedule.pacing_interval, Duration::from_nanos(487_334));
+	}
+
+	#[test]
+	fn accelerates_large_frames_to_meet_budget() {
+		let schedule = batch_schedule(1392, 500, 46, 120_000_000, Duration::from_millis(13));
+		assert_eq!(schedule.segments_per_send, 19);
+		assert!(schedule.deadline_clamped);
+		assert!(schedule.pacing_interval <= TARGET_BURST_DURATION);
+	}
+
+	#[test]
+	fn respects_gso_segment_limit() {
+		let schedule = batch_schedule(1392, 100, 3, 120_000_000, Duration::from_millis(13));
+		assert_eq!(schedule.segments_per_send, 3);
+	}
+}

--- a/moonshine-core/src/session/stream/video/pipeline/mod.rs
+++ b/moonshine-core/src/session/stream/video/pipeline/mod.rs
@@ -328,7 +328,7 @@ async fn run_packet_consumer(
 		let processing_latency = t_start.duration_since(frame_context.created_at);
 		let latency_100us = (processing_latency.as_micros() / 100).min(u16::MAX as u128) as u16;
 
-		let shards = match packetizer.packetize(
+		let mut shards = match packetizer.packetize(
 			&packet.data,
 			is_key_frame,
 			ctx.packet_size,
@@ -350,6 +350,7 @@ async fn run_packet_consumer(
 		};
 
 		let t_packetized = std::time::Instant::now();
+		shards.mark_enqueued();
 
 		// A closed packet channel means the network sender is gone, i.e. the
 		// session is already tearing down. Stop the consumer; the encoding thread

--- a/moonshine-core/src/session/stream/video/shard_batch.rs
+++ b/moonshine-core/src/session/stream/video/shard_batch.rs
@@ -8,6 +8,8 @@ pub(crate) struct ShardBatch {
 	data: Vec<u8>,
 	/// Size of each shard in bytes.
 	shard_size: usize,
+	/// Time this completed frame batch entered the network sender queue.
+	queued_at: Option<std::time::Instant>,
 }
 
 impl ShardBatch {
@@ -16,6 +18,7 @@ impl ShardBatch {
 		Self {
 			data: Vec::new(),
 			shard_size: 0,
+			queued_at: None,
 		}
 	}
 
@@ -32,6 +35,15 @@ impl ShardBatch {
 	/// Number of shards in this batch.
 	pub fn shard_count(&self) -> usize {
 		self.data.len().checked_div(self.shard_size).unwrap_or(0)
+	}
+
+	pub fn mark_enqueued(&mut self) {
+		self.queued_at = Some(std::time::Instant::now());
+	}
+
+	pub fn queue_age(&self) -> std::time::Duration {
+		self.queued_at
+			.map_or(std::time::Duration::ZERO, |queued_at| queued_at.elapsed())
 	}
 
 	/// Append all shards from `other` into this batch.
@@ -122,6 +134,7 @@ impl ShardBuf {
 		ShardBatch {
 			data: self.data,
 			shard_size: self.stride,
+			queued_at: None,
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Moonshine sends the UDP shards for each encoded frame back-to-back. At higher bitrates, that burst can overflow a queue along the path even when the average stream bitrate fits comfortably.

This remains possible after #157: that change splits oversized GSO submissions into valid datagrams, but the resulting packets are still transmitted as a burst.

The original observation was made with GSO disabled. In two 1440p60, 60 Mbps, 1392-byte packet runs over wired Ethernet, unpaced per-shard sends lost 1.04% and 0.79% of frames. Adding a 100 microsecond gap reduced network frame loss to 0.00% in both runs. A five-minute run with a 125 microsecond gap reported 0.00% network loss and 0.01% jitter loss.

## Implementation

`Pacer` derives its target wire rate from the bitrate requested by the client and a configurable headroom percentage:

```toml
[stream.video]
pacing_bitrate_headroom_percent = 200
pacing_frame_budget_percent = 80
```

Pacing defaults to enabled with 200% bitrate headroom. Setting `pacing_bitrate_headroom_percent` to zero disables it.

The pacer uses Linux `timerfd` for sub-millisecond deadlines. GSO remains enabled: each send contains approximately 500 microseconds of segmented wire data, bounded by the kernel segment and datagram limits. Unusually large frames are accelerated to fit the configured fraction of one frame interval.

The sender reports queue age, send duration, send failures, and missed pacing deadlines every five seconds. It does not discard late encoded frames because later inter-frames may reference them; missed deadlines remain visible in the sender counters.

## Follow-up measurements

These measurements use commit `c744dd484c0a`, a controlled pinwheel source, a Steam Deck connected to an LG TV, routed wired Ethernet, 60 FPS, 60 Mbps, 1392-byte packets, 20% FEC, Moonlight frame pacing enabled, and V-sync disabled. The 4K rows are SDR because the synthetic source did not cause Moonlight to create an HDR10 swapchain.

| GSO | Server pacing | Profile | Network drop | Client jitter drop | Network latency | Decode / render | Host maximum send |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
| enabled | disabled | 1440p60 H.264 | 0.00% | 0.07% | 1 ms | 0.57 / 2.96 ms | 96 us |
| enabled | 200% / 80% | 1440p60 H.264 | 0.00% | 0.00% | 1 ms | 0.60 / 3.19 ms | 10.386 ms |
| enabled | disabled | 4K60 AV1 | 0.00% | 0.03% | 1 ms | 0.53 / 8.37 ms | 89 us |
| enabled | 200% / 80% | 4K60 AV1 | 0.00% | 0.07% | 1 ms | 0.46 / 8.41 ms | 10.414 ms |
| disabled | disabled | 1440p60 H.264 | 0.00% | 0.03% | 1 ms | 0.51 / 2.94 ms | 782 us |
| disabled | 200% / 80% | 1440p60 H.264 | 0.00% | 0.00% | 1 ms | 0.62 / 3.14 ms | 10.681 ms |

Two additional 100-second 1440p60 runs per GSO-enabled setting also reported 0.00% network loss. Both unpaced runs reported 0.04% jitter loss; both paced runs reported 0.00%.

Sender telemetry reported zero send errors, failed GSO chunks, pacing-budget misses, and frame-deadline misses in every row. Deck `UdpRcvbufErrors`, `UdpInErrors`, and `IpInDiscards` did not increase, and each packet capture reported zero kernel drops.

Using consecutive packets separated by at most 100 microseconds as a microburst, pacing reduced the largest observed 1440p burst from 109 packets to 30 and the largest 4K burst from 109 packets to 29. On this path that did not reduce network loss, which was already zero, while completing each frame's sends about 10.3 ms later.

The follow-up data therefore confirms that the pacer reshapes bursts, but does not yet justify enabling that latency trade-off on a working GSO path. The PR remains a draft while deciding whether pacing should be opt-in or limited to the per-shard fallback path.
