### PR TITLE
fix(xwm): defer X11 resizing until fullscreen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,7 @@ dependencies = [
  "walkdir",
  "wayland-scanner",
  "which 8.0.5",
+ "x11rb",
  "x509-parser",
  "xcursor",
  "zbus",

--- a/moonshine-core/Cargo.toml
+++ b/moonshine-core/Cargo.toml
@@ -82,3 +82,4 @@ zvariant = "5.12.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+x11rb = "0.13.2"

--- a/moonshine-core/src/session/compositor/focus.rs
+++ b/moonshine-core/src/session/compositor/focus.rs
@@ -202,13 +202,10 @@ impl WindowMetadata {
 
 	/// Returns `true` if the window should be held at the output size.
 	///
-	/// Gamescope holds the focus window at the output size regardless of the
-	/// fullscreen hint, so a game running below the stream resolution is
-	/// scaled up to fill the whole output. Only the main window qualifies —
-	/// dialogs, dropdowns, and Steam overlay/notification windows keep their
-	/// own size.
+	/// Fullscreen can arrive before app-id classification. Steam Big Picture
+	/// also fills the output without setting the fullscreen hint.
 	pub fn should_fill_output(&self) -> bool {
-		self.has_game_id()
+		(self.fullscreen || self.is_steam_big_picture())
 			&& self.transient_for.is_none()
 			&& !self.is_dropdown()
 			&& !self
@@ -388,9 +385,35 @@ mod tests {
 	}
 
 	#[test]
-	fn test_game_is_held_at_output_size_without_the_fullscreen_state() {
+	fn test_only_fullscreen_or_steam_windows_fill_output() {
 		assert!(make_meta(&[("app_id", "769")]).should_fill_output());
-		assert!(make_meta(&[("app_id", "12345")]).should_fill_output());
+		assert!(!make_meta(&[("app_id", "12345")]).should_fill_output());
+		assert!(!make_meta(&[]).should_fill_output());
+		assert!(make_meta(&[("fullscreen", "true")]).should_fill_output());
+		assert!(make_meta(&[("app_id", "12345"), ("fullscreen", "true")]).should_fill_output());
+	}
+
+	#[test]
+	fn test_fullscreen_geometry_does_not_depend_on_classification_order() {
+		let mut m = make_meta(&[("fullscreen", "true")]);
+		assert!(m.should_fill_output());
+		m.app_id = 12345;
+		assert!(m.should_fill_output());
+		m.fullscreen = false;
+		assert!(!m.should_fill_output());
+	}
+
+	#[test]
+	fn test_fullscreen_overlays_keep_their_geometry() {
+		for flag in [
+			WindowFlags::OVERLAY,
+			WindowFlags::NOTIFICATION,
+			WindowFlags::EXTERNAL_OVERLAY,
+		] {
+			let mut m = make_meta(&[("fullscreen", "true")]);
+			m.flags = flag;
+			assert!(!m.should_fill_output());
+		}
 	}
 
 	#[test]
@@ -398,13 +421,14 @@ mod tests {
 		assert!(
 			!make_meta(&[
 				("app_id", "12345"),
+				("fullscreen", "true"),
 				("override_redirect", "true"),
 				("width", "100"),
 				("height", "100"),
 			])
 			.should_fill_output()
 		);
-		let mut m = make_meta(&[("app_id", "12345")]);
+		let mut m = make_meta(&[("app_id", "12345"), ("fullscreen", "true")]);
 		m.transient_for = Some(12345);
 		assert!(!m.should_fill_output());
 	}

--- a/moonshine-core/src/session/compositor/handlers.rs
+++ b/moonshine-core/src/session/compositor/handlers.rs
@@ -1273,7 +1273,7 @@ impl MoonshineCompositor {
 	/// 2. `classify_special_windows()` — overlay/notification/etc. classification
 	/// 3. `build_candidates()` — filter and collect candidate windows
 	/// 4. Steam control override + priority sort
-	/// 5. `enforce_fullscreen_geometry()` — hold the winner at the output size
+	/// 5. `enforce_output_geometry()` — apply the winner's fullscreen geometry
 	/// 6. `apply_focus()` — set keyboard/pointer focus, activation
 	pub fn reevaluate_focus(&mut self) {
 		// Mark focus as dirty before recalculating.
@@ -1396,25 +1396,14 @@ impl MoonshineCompositor {
 		// Transient child promotion.
 		let best = self.promote_transient_child(best);
 
-		// Step 5: Hold the focused game window at the output size.
+		// Step 5: Apply the focused window's fullscreen geometry.
 		self.enforce_output_geometry(&best);
 
 		// Step 6: Apply focus (keyboard/pointer target, activation, Smithay seat).
 		self.apply_focus(&best);
 	}
 
-	/// Resize the focused game window to the output.
-	///
-	/// Gamescope holds the focus window at the output size regardless of the
-	/// fullscreen hint, so a game running below the stream resolution is
-	/// scaled up to fill the whole output. Only the main window is held —
-	/// dialogs, dropdowns, and Steam overlay/notification windows keep their
-	/// own size.
-	///
-	/// Correcting geometry here rather than refusing the client's
-	/// `ConfigureRequest` fixes a wrong-sized window whatever caused it.
-	///
-	/// Gamescope: `determine_and_apply_focus()`
+	/// Apply the same fullscreen policy used for client configure requests.
 	fn enforce_output_geometry(&self, window: &Window) {
 		let Some(meta) = self.window_metadata.get(window) else {
 			return;
@@ -1436,10 +1425,10 @@ impl MoonshineCompositor {
 			window_id = x11.window_id(),
 			current = ?x11.geometry().size,
 			output = ?geo.size,
-			"Resizing game window to output size"
+			"Resizing fullscreen window to output size"
 		);
 		if let Err(e) = x11.configure(geo) {
-			tracing::warn!("Failed to resize game window to output size: {e}");
+			tracing::warn!("Failed to resize fullscreen window to output size: {e}");
 		}
 	}
 
@@ -2072,18 +2061,14 @@ impl XwmHandler for MoonshineCompositor {
 			target: "focus",
 			title = ?window.title(),
 			class = ?window.class(),
+			geometry = ?window.geometry(),
 			override_redirect = window.is_override_redirect(),
 			wl_surface = ?window.wl_surface(),
 			"X11 window map request"
 		);
 
-		// Configure the X11 window to fill the output.
-		let geo = self.output_rect();
-		if let Err(e) = window.configure(geo) {
-			tracing::warn!("Failed to configure X11 window geometry: {e}");
-		}
-
-		// Grant the map request.
+		// Preserve client geometry while decorations and rendering children
+		// are being established; mapping does not imply fullscreen.
 		if let Err(e) = window.set_mapped(true) {
 			tracing::error!("Failed to set X11 window mapped: {e}");
 			return;
@@ -2304,22 +2289,16 @@ impl XwmHandler for MoonshineCompositor {
 		h: Option<u32>,
 		_reorder: Option<Reorder>,
 	) {
-		// Gamescope holds the game window at the output size, so a game
-		// running below the stream resolution is scaled up to fill the whole
-		// output. This also anchors the WSI swapchain extent (read from the
-		// X11 window) to the output before the game creates it.
 		let elem = self.find_window_by_x11_surface(&window);
-		let is_game = elem
+		let should_fill_output = elem
 			.as_ref()
 			.is_some_and(|e| self.window_metadata.get(e).is_some_and(|m| m.should_fill_output()));
-		if is_game {
+		if should_fill_output {
 			let _ = window.configure(self.output_rect());
 			return;
 		}
 
-		// Grant geometry changes but ignore position (we control placement).
-		// `enforce_output_geometry` corrects a game window that resizes itself
-		// away from the output.
+		// Windowed clients own their size; the compositor controls placement.
 		let mut geo = window.geometry();
 		if let Some(w) = w {
 			geo.size.w = w as i32;

--- a/moonshine-core/src/session/compositor/mod.rs
+++ b/moonshine-core/src/session/compositor/mod.rs
@@ -15,6 +15,9 @@ mod protocols;
 mod state;
 mod x11_focus;
 
+#[cfg(test)]
+mod x11_geometry_tests;
+
 use std::sync::mpsc;
 
 use async_shutdown::ShutdownManager;

--- a/moonshine-core/src/session/compositor/x11_geometry_tests.rs
+++ b/moonshine-core/src/session/compositor/x11_geometry_tests.rs
@@ -1,0 +1,159 @@
+use std::os::unix::process::CommandExt;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use x11rb::connection::Connection;
+use x11rb::protocol::xproto::{
+	AtomEnum, ClientMessageEvent, ConfigureWindowAux, ConnectionExt, CreateWindowAux, EventMask, MapState, PropMode,
+	WindowClass,
+};
+use x11rb::wrapper::ConnectionExt as _;
+
+use super::*;
+
+struct GameProcess(Child);
+
+impl Drop for GameProcess {
+	fn drop(&mut self) {
+		let _ = self.0.kill();
+		let _ = self.0.wait();
+	}
+}
+
+fn wait_until(description: &str, mut condition: impl FnMut() -> bool) {
+	let deadline = Instant::now() + Duration::from_secs(5);
+	while !condition() {
+		assert!(Instant::now() < deadline, "timed out: {description}");
+		std::thread::sleep(Duration::from_millis(10));
+	}
+}
+
+#[test]
+#[ignore = "requires a DRM render node, Xwayland and XDG_RUNTIME_DIR"]
+fn test_x11_geometry_lifecycle() {
+	let stop = ShutdownManager::new();
+	let cleanup = stop.trigger_shutdown_token(SessionShutdownReason::UserStopped);
+	let (compositor, _handles) = Compositor::new(
+		CompositorConfig {
+			hdr: false,
+			..Default::default()
+		},
+		CompositorContext {
+			width: 1280,
+			height: 720,
+			refresh_rate: 60,
+			hdr: false,
+		},
+		stop.clone(),
+	);
+	let compositor = compositor.launch().expect("start test compositor");
+	let display = format!(":{}", compositor.ready().xdisplay);
+	let (conn, screen) = x11rb::connect(Some(&display)).unwrap();
+	let root = conn.setup().roots[screen].root;
+	let atom = |name: &[u8]| conn.intern_atom(false, name).unwrap().reply().unwrap().atom;
+	let wm_state = atom(b"_NET_WM_STATE");
+	let fullscreen = atom(b"_NET_WM_STATE_FULLSCREEN");
+	let pid = atom(b"_NET_WM_PID");
+	let game = GameProcess(Command::new("sleep").arg0("AppId=12345").arg("60").spawn().unwrap());
+
+	let window = conn.generate_id().unwrap();
+	conn.create_window(
+		x11rb::COPY_DEPTH_FROM_PARENT,
+		window,
+		root,
+		0,
+		0,
+		800,
+		600,
+		0,
+		WindowClass::INPUT_OUTPUT,
+		0,
+		&CreateWindowAux::new().background_pixel(0x808080),
+	)
+	.unwrap()
+	.check()
+	.unwrap();
+	conn.map_window(window).unwrap().check().unwrap();
+	conn.flush().unwrap();
+	wait_until("window mapped", || {
+		conn.get_window_attributes(window).unwrap().reply().unwrap().map_state == MapState::VIEWABLE
+	});
+	let size = || {
+		let geo = conn.get_geometry(window).unwrap().reply().unwrap();
+		(geo.width, geo.height)
+	};
+	assert_eq!(size(), (800, 600), "mapping must preserve client size");
+
+	// Classification must not turn a windowed client into a fullscreen one.
+	conn.change_property32(PropMode::REPLACE, window, pid, AtomEnum::CARDINAL, &[game.0.id()])
+		.unwrap()
+		.check()
+		.unwrap();
+	conn.configure_window(window, &ConfigureWindowAux::new().width(900).height(650))
+		.unwrap()
+		.check()
+		.unwrap();
+	conn.flush().unwrap();
+	wait_until("windowed configure request", || size() == (900, 650));
+
+	// A fresh mapping without _NET_WM_PID exercises fullscreen before classification.
+	conn.unmap_window(window).unwrap().check().unwrap();
+	wait_until("window unmapped", || {
+		conn.get_window_attributes(window).unwrap().reply().unwrap().map_state == MapState::UNMAPPED
+	});
+	conn.delete_property(window, pid).unwrap().check().unwrap();
+	conn.map_window(window).unwrap().check().unwrap();
+	wait_until("window remapped", || {
+		conn.get_window_attributes(window).unwrap().reply().unwrap().map_state == MapState::VIEWABLE
+	});
+	let set_fullscreen = |enabled: bool| {
+		let event = ClientMessageEvent::new(32, window, wm_state, [u32::from(enabled), fullscreen, 0, 1, 0]);
+		conn.send_event(
+			false,
+			root,
+			EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+			event,
+		)
+		.unwrap()
+		.check()
+		.unwrap();
+		conn.flush().unwrap();
+		wait_until("fullscreen acknowledgement", || {
+			let reply = conn
+				.get_property(false, window, wm_state, AtomEnum::ATOM, 0, 32)
+				.unwrap()
+				.reply()
+				.unwrap();
+			reply
+				.value32()
+				.is_some_and(|mut values| values.any(|value| value == fullscreen))
+				== enabled
+		});
+	};
+	set_fullscreen(true);
+	wait_until("fullscreen without an app ID", || size() == (1280, 720));
+
+	conn.configure_window(window, &ConfigureWindowAux::new().width(700).height(500))
+		.unwrap()
+		.check()
+		.unwrap();
+	conn.flush().unwrap();
+	// Observe a settling interval: accepting 700x500 even briefly is a regression.
+	let deadline = Instant::now() + Duration::from_millis(200);
+	while Instant::now() < deadline {
+		assert_eq!(size(), (1280, 720), "fullscreen configure must retain output size");
+		std::thread::sleep(Duration::from_millis(10));
+	}
+
+	set_fullscreen(false);
+	conn.configure_window(window, &ConfigureWindowAux::new().width(800).height(600))
+		.unwrap()
+		.check()
+		.unwrap();
+	conn.flush().unwrap();
+	wait_until("windowed geometry after leaving fullscreen", || size() == (800, 600));
+	conn.destroy_window(window).unwrap().check().unwrap();
+	drop(conn);
+	drop(cleanup);
+	wait_until("compositor shutdown", || stop.is_shutdown_completed());
+}


### PR DESCRIPTION
Fixes #188.

`map_window_request()` resizes every X11 window to the output size before it asks for fullscreen. With Resonance, Wine's toplevel becomes 3840x2160 while the actual rendering child ends up at 3834x2128. That mismatch trips `can_bypass_xwayland()`, the bypass gets rejected, and the stream stays black.

The fix leaves the window geometry alone at map time and lets the existing `enforce_fullscreen_geometry()` path resize it once it is actually fullscreen.

Also drops the `has_game_id()` check. Steam Big Picture requests fullscreen while its app ID is still 0, so keeping that check leaves Steam at 1280x800 instead of filling the output.

Tested end to end at 4K: both Steam login and Big Picture still work correctly and fill in the screen, and the faulty game (A Plague Tale Legacy: Resonance) launches at the correct size too.