### PR TITLE
Moonlight web only expects positive IDs for applications

### DIFF
--- a/moonshine-core/src/session/application.rs
+++ b/moonshine-core/src/session/application.rs
@@ -68,7 +68,8 @@ impl ApplicationConfig {
 	pub fn id(&self) -> i32 {
 		let mut hasher = DefaultHasher::new();
 		self.title.hash(&mut hasher);
-		hasher.finish() as i32
+		// Clients only accept non-negative application IDs.
+		(hasher.finish() as i32) & i32::MAX
 	}
 }
 


### PR DESCRIPTION
Moonlight web throws an "invalid digit"-Error when parsing the applist, since "-" is not valid when only looking for u32/positive numbers.

I don't know what the standard practice is for this case, but keeping Moonshine as compatible as possible seems like the right thing in my eyes.