### PR TITLE
fix: empty string for PA source instead of null

### DIFF
--- a/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
+++ b/moonshine-core/src/session/stream/audio/pulse_server/mod.rs
@@ -263,7 +263,7 @@ impl PulseServer {
 			server_version: Some(std::ffi::CString::new(env!("CARGO_PKG_VERSION")).unwrap()),
 			host_name: Some(std::ffi::CString::new("moonshine").unwrap()),
 			default_sink_name: Some(sink_name.clone()),
-			default_source_name: None,
+			default_source_name: Some(std::ffi::CString::new("").unwrap()),
 			sample_spec: capture_spec,
 			channel_map,
 			..Default::default()


### PR DESCRIPTION
Factorio does a strlen() of the PA source, which causes it to crash if a null pointer is passed. Fix for #179. Verified that it still works with Project Zomboid, which crashed on passing a dummy value (see #173)